### PR TITLE
2.0.1 Release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Add [the NuGet package](https://nuget.org/packages/seq.extensions.logging) to th
 
 ```json
     "dependencies": {
-        "Seq.Extensions.Logging": "2.0.0"
+        "Seq.Extensions.Logging": "2.0.1"
     }
 ```
 

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/ControlledLevelSwitch.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/ControlledLevelSwitch.cs
@@ -1,0 +1,73 @@
+﻿// Serilog.Sinks.Seq Copyright 2016 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using Microsoft.Extensions.Logging;
+using Serilog.Core;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Seq
+{
+    /// <summary>
+    /// Instances of this type are single-threaded, generally only updated on a background
+    /// timer thread. An exception is <see cref="IsIncluded(LogEvent)"/>, which may be called
+    /// concurrently but performs no synchronization.
+    /// </summary>
+    class ControlledLevelSwitch
+    {
+        // If non-null, then background level checks will be performed; set either through the constructor
+        // or in response to a level specification from the server. Never set to null after being made non-null.
+        LoggingLevelSwitch _controlledSwitch;
+        LogLevel? _originalLevel;
+
+        public ControlledLevelSwitch(LoggingLevelSwitch controlledSwitch = null)
+        {
+            _controlledSwitch = controlledSwitch;
+        }
+
+        public bool IsActive => _controlledSwitch != null;
+
+        public bool IsIncluded(LogEvent evt)
+        {
+            // Concurrent, but not synchronized.
+            var controlledSwitch = _controlledSwitch;
+            return controlledSwitch == null ||
+                (int)controlledSwitch.MinimumLevel <= (int)evt.Level;
+        }
+
+        public void Update(LogLevel? minimumAcceptedLevel)
+        {
+            if (minimumAcceptedLevel == null)
+            {
+                if (_controlledSwitch != null && _originalLevel.HasValue)
+                    _controlledSwitch.MinimumLevel = _originalLevel.Value;
+
+                return;
+            }
+
+            if (_controlledSwitch == null)
+            {
+                // The server is controlling the logging level, but not the overall logger. Hence, if the server
+                // stops controlling the level, the switch should become transparent.
+                _originalLevel = LevelAlias.Minimum;
+                _controlledSwitch = new LoggingLevelSwitch(minimumAcceptedLevel.Value);
+                return;
+            }
+
+            if (!_originalLevel.HasValue)
+                _originalLevel = _controlledSwitch.MinimumLevel;
+
+            _controlledSwitch.MinimumLevel = minimumAcceptedLevel.Value;
+        }
+    }
+}

--- a/src/Seq.Extensions.Logging/project.json
+++ b/src/Seq.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-*",
+  "version": "2.0.1-*",
 
   "description": "Add centralized structured log collection to ASP.NET Core apps with one line of code.",
   "authors": [ "Datalust and Contributors" ],

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -10,12 +10,11 @@ using System.IO;
 using System.Linq;
 using Xunit;
 using Serilog.Extensions.Logging;
-using Serilog;
 using Seq.Extensions.Logging;
 using Tests.Serilog.Extensions.Logging.Support;
 using Serilog.Core.Enrichers;
 
-namespace Tests.Serilog.Extensions
+namespace Tests.Serilog.Extensions.Logging
 {
     public class SerilogLoggerTest
     {

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/ControlledLevelSwitchTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/ControlledLevelSwitchTests.cs
@@ -1,0 +1,91 @@
+﻿using Microsoft.Extensions.Logging;
+using Serilog.Core;
+using Serilog.Sinks.Seq;
+using Tests.Support;
+using Xunit;
+
+namespace Tests.Serilog.Sinks.Seq
+{
+    public class ControlledLevelSwitchTests
+    {
+        [Fact]
+        public void WhenTheServerSendsALevelTheSwitchIsAdjusted()
+        {
+            var lls = new LoggingLevelSwitch(LogLevel.Warning);
+            var cls = new ControlledLevelSwitch(lls);
+            cls.Update(LogLevel.Debug);
+            Assert.Equal(LogLevel.Debug, lls.MinimumLevel);
+        }
+
+        [Fact]
+        public void WhenTheServerSendsNoLevelTheSwitchIsNotInitiallyAdjusted()
+        {
+            var lls = new LoggingLevelSwitch(LogLevel.Warning);
+            lls.MinimumLevel = LogLevel.Critical;
+            var cls = new ControlledLevelSwitch(lls);
+            cls.Update(null);
+            Assert.Equal(LogLevel.Critical, lls.MinimumLevel);
+        }
+
+        [Fact]
+        public void WhenTheServerSendsNoLevelTheSwitchIsResetIfPreviouslyAdjusted()
+        {
+            var lls = new LoggingLevelSwitch(LogLevel.Warning);
+            var cls = new ControlledLevelSwitch(lls);
+            cls.Update(LogLevel.Information);
+            cls.Update(null);
+            Assert.Equal(LogLevel.Warning, lls.MinimumLevel);
+        }
+
+        [Fact]
+        public void WithNoSwitchToControlAllEventsAreIncluded()
+        {
+            var cls = new ControlledLevelSwitch(null);
+            Assert.True(cls.IsIncluded(Some.DebugEvent()));
+        }
+
+        [Fact]
+        public void WithNoSwitchToControlEventsAreStillFiltered()
+        {
+            var cls = new ControlledLevelSwitch(null);
+            cls.Update(LogLevel.Warning);
+            Assert.True(cls.IsIncluded(Some.ErrorEvent()));
+            Assert.False(cls.IsIncluded(Some.InformationEvent()));
+        }
+
+        [Fact]
+        public void WithNoSwitchToControlAllEventsAreIncludedAfterReset()
+        {
+            var cls = new ControlledLevelSwitch(null);
+            cls.Update(LogLevel.Warning);
+            cls.Update(null);
+            Assert.True(cls.IsIncluded(Some.DebugEvent()));
+        }
+
+        [Fact]
+        public void WhenControllingASwitchTheControllerIsActive()
+        {
+            var cls = new ControlledLevelSwitch(new LoggingLevelSwitch());
+            Assert.True(cls.IsActive);
+        }
+
+        [Fact]
+        public void WhenNotControllingASwitchTheControllerIsNotActive()
+        {
+            var cls = new ControlledLevelSwitch();
+            Assert.False(cls.IsActive);
+        }
+
+        [Fact]
+        public void AfterServerControlhTheControllerIsAlwaysActive()
+        {
+            var cls = new ControlledLevelSwitch();
+
+            cls.Update(LogLevel.Information);
+            Assert.True(cls.IsActive);
+
+            cls.Update(null);
+            Assert.True(cls.IsActive);
+        }
+    }
+}

--- a/test/Seq.Extensions.Logging.Tests/Support/Some.cs
+++ b/test/Seq.Extensions.Logging.Tests/Support/Some.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using Serilog.Events;
+using Xunit.Sdk;
+using Serilog.Core;
+using Microsoft.Extensions.Logging;
+
+namespace Tests.Support
+{
+    static class Some
+    {
+        public static LogEvent LogEvent(string messageTemplate, params object[] propertyValues)
+        {
+            return LogEvent(null, messageTemplate, propertyValues);
+        }
+
+        public static LogEvent LogEvent(Exception exception, string messageTemplate, params object[] propertyValues)
+        {
+            return LogEvent(LogLevel.Information, exception, messageTemplate, propertyValues);
+        }
+
+        public static LogEvent LogEvent(LogLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+        {
+            var log = new Logger(null, null, null);
+            MessageTemplate template;
+            IEnumerable<LogEventProperty> properties;
+#pragma warning disable Serilog004 // Constant MessageTemplate verifier
+            if (!log.BindMessageTemplate(messageTemplate, propertyValues, out template, out properties))
+#pragma warning restore Serilog004 // Constant MessageTemplate verifier
+            {
+                throw new XunitException("Template could not be bound.");
+            }
+            return new LogEvent(DateTimeOffset.Now, level, exception, template, properties);
+        }
+
+        public static LogEvent DebugEvent()
+        {
+            return LogEvent(LogLevel.Debug, null, "Debug event");
+        }
+
+        public static LogEvent InformationEvent()
+        {
+            return LogEvent(LogLevel.Information, null, "Information event");
+        }
+
+        public static LogEvent ErrorEvent()
+        {
+            return LogEvent(LogLevel.Error, null, "Error event");
+        }
+    }
+}


### PR DESCRIPTION
Fixes dynamic level control when no server-side level is set by the API key. See: https://github.com/serilog/serilog-sinks-seq/issues/41.