### PR TITLE
Named scope support

### DIFF
--- a/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerProvider.cs
@@ -12,6 +12,7 @@ using Microsoft.Extensions.Logging;
 using Serilog.Core;
 using Serilog.Events;
 using FrameworkLogger = Microsoft.Extensions.Logging.ILogger;
+using System.Collections.Generic;
 
 namespace Serilog.Extensions.Logging
 {
@@ -21,6 +22,7 @@ namespace Serilog.Extensions.Logging
     class SerilogLoggerProvider : ILoggerProvider, ILogEventEnricher
     {
         internal const string OriginalFormatPropertyName = "{OriginalFormat}";
+        internal const string ScopePropertyName = "Scope";
 
         // May be null; if it is, Log.Logger will be lazily used
         readonly Logger _logger;
@@ -54,9 +56,22 @@ namespace Serilog.Extensions.Logging
         /// <inheritdoc />
         public void Enrich(LogEvent logEvent, ILogEventPropertyFactory propertyFactory)
         {
+            List<ScalarValue> names = null;
             for (var scope = CurrentScope; scope != null; scope = scope.Parent)
             {
                 scope.Enrich(logEvent, propertyFactory);
+
+                string name;
+                if (scope.TryGetName(out name))
+                {
+                    names = names ?? new List<ScalarValue>();
+                    names.Add(new ScalarValue(name));
+                }
+            }
+            if (names != null)
+            {
+                names.Reverse();
+                logEvent.AddPropertyIfAbsent(new LogEventProperty(ScopePropertyName, new SequenceValue(names)));
             }
         }
 

--- a/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerProvider.cs
@@ -68,6 +68,7 @@ namespace Serilog.Extensions.Logging
                     names.Add(new ScalarValue(name));
                 }
             }
+
             if (names != null)
             {
                 names.Reverse();

--- a/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerScope.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerScope.cs
@@ -72,5 +72,11 @@ namespace Serilog.Extensions.Logging
                 }
             }
         }
+
+        public bool TryGetName(out string name)
+        {
+            name = _state as string;
+            return name != null;
+        }
     }
 }

--- a/src/Seq.Extensions.Logging/project.json
+++ b/src/Seq.Extensions.Logging/project.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.2-*",
+  "version": "2.1.0-*",
 
   "description": "Add centralized structured log collection to ASP.NET Core apps with one line of code.",
   "authors": [ "Datalust and Contributors" ],

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -319,7 +319,31 @@ namespace Tests.Serilog.Extensions.Logging
             Assert.True(sink.Writes[0].Properties.ContainsKey("FirstName"));
         }
 
-        private class FoodScope : IEnumerable<KeyValuePair<string, object>>
+        [Fact]
+        public void NamedScopesAreCaptured()
+        {
+            var t = SetUp(LogLevel.Trace);
+            var logger = t.Item1;
+            var sink = t.Item2;
+
+            using (logger.BeginScope("Outer"))
+            using (logger.BeginScope("Inner"))
+            {
+                logger.Log(LogLevel.Information, 0, TestMessage, null, null);
+            }
+
+            Assert.Equal(1, sink.Writes.Count);
+
+            LogEventPropertyValue scopeValue;
+            Assert.True(sink.Writes[0].Properties.TryGetValue(SerilogLoggerProvider.ScopePropertyName, out scopeValue));
+
+            var items = (scopeValue as SequenceValue)?.Elements.Select(e => ((ScalarValue)e).Value).Cast<string>().ToArray();
+            Assert.Equal(2, items.Length);
+            Assert.Equal("Outer", items[0]);
+            Assert.Equal("Inner", items[1]);
+        }
+
+private class FoodScope : IEnumerable<KeyValuePair<string, object>>
         {
             readonly string _name;
 

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -343,7 +343,7 @@ namespace Tests.Serilog.Extensions.Logging
             Assert.Equal("Inner", items[1]);
         }
 
-private class FoodScope : IEnumerable<KeyValuePair<string, object>>
+        private class FoodScope : IEnumerable<KeyValuePair<string, object>>
         {
             readonly string _name;
 


### PR DESCRIPTION
Adds a `Scope` property to log messages when `ILogger.BeginScope(string)` is used.