### PR TITLE
Ensure events with a null message template and/or state are logged

### DIFF
--- a/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLogger.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLogger.cs
@@ -95,21 +95,32 @@ namespace Serilog.Extensions.Logging
                 }
             }
 
-            if (messageTemplate == null && state != null)
+            if (messageTemplate == null)
             {
-                messageTemplate = "{State:l}";
-                LogEventProperty stateProperty;
-                if (logger.BindProperty("State", AsLoggableValue(state, formatter), false, out stateProperty))
-                    properties.Add(stateProperty);
-            }
+                string propertyName = null;
+                if (state != null)
+                {
+                    propertyName = "State";
+                    messageTemplate = "{State:l}";
+                }
+                else if (formatter != null)
+                {
+                    propertyName = "Message";
+                    messageTemplate = "{Message:l}";
+                }
 
-            if (string.IsNullOrEmpty(messageTemplate))
-                return;
+                if (propertyName != null)
+                {
+                    LogEventProperty property;
+                    if (logger.BindProperty(propertyName, AsLoggableValue(state, formatter), false, out property))
+                        properties.Add(property);
+                }
+            }
 
             if (eventId.Id != 0 || eventId.Name != null)
                 properties.Add(CreateEventIdProperty(eventId));
 
-            var parsedTemplate = _messageTemplateParser.Parse(messageTemplate);
+            var parsedTemplate = _messageTemplateParser.Parse(messageTemplate ?? "");
             var evt = new LogEvent(DateTimeOffset.Now, level, exception, parsedTemplate, properties);
             logger.Write(evt);
         }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -125,9 +125,20 @@ namespace Tests.Serilog.Extensions.Logging
 
             logger.Log<object>(LogLevel.Information, 0, null, null, null);
             logger.Log(LogLevel.Information, 0, TestMessage, null, null);
+            logger.Log<object>(LogLevel.Information, 0, null, null, (_, __) => TestMessage);
 
-            Assert.Equal(1, sink.Writes.Count);
-            Assert.Equal(TestMessage, sink.Writes[0].RenderMessage());
+            Assert.Equal(3, sink.Writes.Count);
+
+            Assert.Equal(1, sink.Writes[0].Properties.Count);
+            Assert.Empty(sink.Writes[0].RenderMessage());
+
+            Assert.Equal(2, sink.Writes[1].Properties.Count);
+            Assert.True(sink.Writes[1].Properties.ContainsKey("State"));
+            Assert.Equal(TestMessage, sink.Writes[1].RenderMessage());
+
+            Assert.Equal(2, sink.Writes[2].Properties.Count);
+            Assert.True(sink.Writes[2].Properties.ContainsKey("Message"));
+            Assert.Equal(TestMessage, sink.Writes[2].RenderMessage());
         }
 
         [Fact]


### PR DESCRIPTION
Port of fix from https://github.com/serilog/serilog-extensions-logging/pull/67 by @skomis-mm to ensure all events are logged.