### PR TITLE
Don't apply level filtering when running under .NET Core 2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,44 @@ This package makes it a one-liner to configure ASP.NET Core logging with Seq.
 
 ### Getting started
 
+The instructions that follow are for **.NET Core 2.0+**.
+
 Add [the NuGet package](https://nuget.org/packages/seq.extensions.logging) to your project either by editing the CSPROJ file, or using the NuGet package manager:
 
 ```powershell
 Install-Package Seq.Extensions.Logging
 ```
 
-In your `Startup` class's `Configure()` method, call `AddSeq()` on the provided `loggerFactory`.
+In `Program.cs`, call `AddSeq()` on the provided `loggingBuilder`.
 
 ```csharp
-    public void ConfigureServices(IServiceCollection services)
-    {
-        services.AddLogging(loggingBuilder =>
-            loggingBuilder.AddSeq("http://localhost:5341"));
+public static void Main(string[] args)
+{
+    var webHost = new WebHostBuilder()
+        .UseKestrel()
+        .UseContentRoot(Directory.GetCurrentDirectory())
+        .ConfigureAppConfiguration((hostingContext, config) =>
+        {
+            var env = hostingContext.HostingEnvironment;
+            config.AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                  .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true, reloadOnChange: true);
+            config.AddEnvironmentVariables();
+        })
+        .ConfigureLogging((hostingContext, logging) =>
+        {
+            logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
+
+			// Add this line
+			logging.AddSeq("http://localhost:5341")
+
+            logging.AddConsole();
+            logging.AddDebug();
+        })
+        .UseStartup<Startup>()
+        .Build();
+
+    webHost.Run();
+}
 ```
 
 The framework will inject `ILogger` instances into controllers and other classes:
@@ -77,24 +102,34 @@ The `AddSeq()` method exposes some basic options for controlling the connection 
 
 ### JSON configuration
 
-The Seq server URL, API key and other settings can be read from JSON configuration if desired.
+The logging level, Seq server URL, API key and other settings can be read from JSON configuration if desired.
 
-In `appsettings.json` add a `"Seq"` property:
+In `appsettings.json` add a `"Seq"` property to `"Logging"` to configure levels for the Seq provider:
 
 ```json
 {
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Information"
+    },
+    "Seq": {
+      "LogLevel": {
+        "Default": "Trace",
+        "System": "Information",
+        "Microsoft": "Warning"
+      }
+    }
+  },
   "Seq": {
     "ServerUrl": "http://localhost:5341",
     "ApiKey": "1234567890",
-    "MinimumLevel": "Trace",
-    "LevelOverride": {
-      "Microsoft": "Warning"
-    }
   }
 }
 ```
 
-And then pass the configuration section to the `AddSeq()` method:
+An additional root `"Seq"` property is used to configure the server URL and API key. To use this,
+pass the configuration section to the `AddSeq()` method:
 
 ```csharp
         loggingBuilder.AddSeq(Configuration.GetSection("Seq"));

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add [the NuGet package](https://nuget.org/packages/seq.extensions.logging) to yo
 Install-Package Seq.Extensions.Logging
 ```
 
-In `Program.cs`, call `AddSeq()` on the provided `loggingBuilder`.
+In `Program.cs`, call `AddSeq()` on the provided `ILoggingBuilder`.
 
 ```csharp
 public static void Main(string[] args)
@@ -37,8 +37,8 @@ public static void Main(string[] args)
         {
             logging.AddConfiguration(hostingContext.Configuration.GetSection("Logging"));
 
-			// Add this line
-			logging.AddSeq("http://localhost:5341")
+            // Add this line
+            logging.AddSeq("http://localhost:5341")
 
             logging.AddConsole();
             logging.AddDebug();
@@ -132,7 +132,7 @@ An additional root `"Seq"` property is used to configure the server URL and API 
 pass the configuration section to the `AddSeq()` method:
 
 ```csharp
-        loggingBuilder.AddSeq(Configuration.GetSection("Seq"));
+        logging.AddSeq(Configuration.GetSection("Seq"));
 ```
 
 ### Dynamic log level control

--- a/example/WebApplication/Controllers/HomeController.cs
+++ b/example/WebApplication/Controllers/HomeController.cs
@@ -19,6 +19,7 @@ namespace WebApplication.Controllers
         public IActionResult Index()
         {
             _log.LogInformation("Hello, {Name}!", "world");
+            _log.LogDebug("Hello, again!");
 
             using (_log.BeginScope("Example"))
             using (_log.BeginScope(42))

--- a/example/WebApplication/Startup.cs
+++ b/example/WebApplication/Startup.cs
@@ -25,6 +25,9 @@ namespace WebApplication
         {
             services.AddLogging(loggingBuilder =>
             {
+                loggingBuilder.ClearProviders();
+                loggingBuilder.AddConfiguration(Configuration.GetSection("Logging"));
+                
                 // Add a Seq logger.
                 loggingBuilder.AddSeq(Configuration.GetSection("Seq"));
 

--- a/example/WebApplication/appsettings.json
+++ b/example/WebApplication/appsettings.json
@@ -1,11 +1,19 @@
 ﻿{
+  "Logging": {
+    "IncludeScopes": false,
+    "LogLevel": {
+      "Default": "Information"
+    },
+    "Seq": {
+      "LogLevel": {
+        "Default": "Trace",
+        "System": "Information",
+        "Microsoft": "Warning"
+      }
+    }
+  },
   "Seq": {
     "ServerUrl": "http://localhost:5341",
-    "ApiKey": "",
-    "MinimumLevel": "Debug",
-    "LevelOverride": {
-      "System": "Information",
-      "Microsoft": "Information"
-    }
+    "ApiKey": ""
   }
 }

--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Add centralized structured log collection to ASP.NET Core apps with one line of code.</Description>
-    <VersionPrefix>3.0.0</VersionPrefix>
+    <VersionPrefix>4.0.0</VersionPrefix>
     <Authors>Datalust and Contributors</Authors>
     <TargetFrameworks>net45;net46;net461;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>


### PR DESCRIPTION
A shot at #22. Adds the `"Seq"` provider alias.

Breaks `ILoggingBuilder.AddSeq()` by removing level configuration.