### PR TITLE
Fix a bug preventing the logging pipeline from being flushed on provider disposal

### DIFF
--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Add centralized structured log collection to ASP.NET Core apps with one line of code.</Description>
-    <VersionPrefix>4.0.0</VersionPrefix>
+    <VersionPrefix>4.0.1</VersionPrefix>
     <Authors>Datalust and Contributors</Authors>
     <TargetFrameworks>net45;net46;net461;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerProvider.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLoggerProvider.cs
@@ -27,8 +27,8 @@ namespace Serilog.Extensions.Logging
         internal const string OriginalFormatPropertyName = "{OriginalFormat}";
         internal const string ScopePropertyName = "Scope";
 
-        // May be null; if it is, Log.Logger will be lazily used
         readonly Logger _logger;
+        readonly Action _dispose;
 
         /// <summary>
         /// Construct a <see cref="SerilogLoggerProvider"/>.
@@ -39,6 +39,7 @@ namespace Serilog.Extensions.Logging
             if (logger == null)
                 throw new ArgumentNullException(nameof(logger));
 
+            _dispose = logger.Dispose;
             _logger = logger.ForContext(new[] { this });
         }
 
@@ -48,7 +49,6 @@ namespace Serilog.Extensions.Logging
             return new SerilogLogger(this, _logger, name);
         }
 
-        /// <inheritdoc />
         public IDisposable BeginScope<T>(T state)
         {
             return new SerilogLoggerScope(this, state);
@@ -102,7 +102,7 @@ namespace Serilog.Extensions.Logging
         /// <inheritdoc />
         public void Dispose()
         {
-            _logger.Dispose();
+            _dispose();
         }
     }
 }


### PR DESCRIPTION
I think this was a mistake made in the "simplification" of the embedded Serilog code we use in this lib.