### PR TITLE
Fixes #29, dispose not called when registered with LoggingBuilder

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2017
-configuration: Release
+image: Visual Studio 2019
 build_script:
 - ps: ./Build.ps1
 test: off

--- a/example/ConsoleApplication/ConsoleApplication.csproj
+++ b/example/ConsoleApplication/ConsoleApplication.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Seq.Extensions.Logging\Seq.Extensions.Logging.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="3.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="3.0.1" />
+  </ItemGroup>
+
+</Project>

--- a/example/ConsoleApplication/Program.cs
+++ b/example/ConsoleApplication/Program.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace ConsoleApplication
+{
+    class Program
+    {
+        static void Main()
+        {
+            using var services = new ServiceCollection()
+                .AddLogging(builder => builder
+                    .SetMinimumLevel(LogLevel.Trace)
+                    .AddConsole()
+                    .AddSeq())
+                .BuildServiceProvider();
+
+            var logger = services.GetRequiredService<ILogger<Program>>();
+
+            logger.LogInformation("Hello, {Name}!", Environment.UserName);
+        }
+    }
+}

--- a/seq-extensions-logging.sln
+++ b/seq-extensions-logging.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29326.143
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{0069BFD6-B0EE-4204-A85F-F75E31A77B3C}"
 EndProject
@@ -23,6 +23,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Seq.Extensions.Logging.Test
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WebApplication", "example\WebApplication\WebApplication.csproj", "{FC44EC1F-AD83-4522-99B4-4B309B8CC78A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ConsoleApplication", "example\ConsoleApplication\ConsoleApplication.csproj", "{3C7C4F1B-7BB1-48F6-BC9E-0A81F632458B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -41,6 +43,10 @@ Global
 		{FC44EC1F-AD83-4522-99B4-4B309B8CC78A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FC44EC1F-AD83-4522-99B4-4B309B8CC78A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FC44EC1F-AD83-4522-99B4-4B309B8CC78A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3C7C4F1B-7BB1-48F6-BC9E-0A81F632458B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3C7C4F1B-7BB1-48F6-BC9E-0A81F632458B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3C7C4F1B-7BB1-48F6-BC9E-0A81F632458B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3C7C4F1B-7BB1-48F6-BC9E-0A81F632458B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -49,6 +55,7 @@ Global
 		{E640A22A-DF3C-40A2-AC72-DEB2F9B16241} = {0069BFD6-B0EE-4204-A85F-F75E31A77B3C}
 		{64A3F2C5-D71E-44A6-8DC7-99474765B32E} = {D54DE844-AC36-4872-928F-5F573D41ACAE}
 		{FC44EC1F-AD83-4522-99B4-4B309B8CC78A} = {1C72E771-7C72-4A30-A408-5CE66E792ADF}
+		{3C7C4F1B-7BB1-48F6-BC9E-0A81F632458B} = {1C72E771-7C72-4A30-A408-5CE66E792ADF}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A6DD7789-D2A5-43A4-A4FE-E138166E15C7}

--- a/src/Seq.Extensions.Logging/Microsoft/Extensions/Logging/SeqLoggerExtensions.cs
+++ b/src/Seq.Extensions.Logging/Microsoft/Extensions/Logging/SeqLoggerExtensions.cs
@@ -7,6 +7,10 @@ using Serilog.Events;
 using Serilog.Extensions.Logging;
 using Serilog.Sinks.Seq;
 
+#if LOGGING_BUILDER
+using Microsoft.Extensions.DependencyInjection;
+#endif
+
 namespace Microsoft.Extensions.Logging
 {
     /// <summary>
@@ -77,7 +81,7 @@ namespace Microsoft.Extensions.Logging
 
             var provider = CreateProvider(serverUrl, apiKey, LevelAlias.Minimum, null);
 
-            loggingBuilder.AddProvider(provider);
+            loggingBuilder.Services.AddSingleton<ILoggerProvider>(_ => provider);
 
             return loggingBuilder;
         }
@@ -96,7 +100,7 @@ namespace Microsoft.Extensions.Logging
             if (configuration == null) throw new ArgumentNullException(nameof(configuration));
 
             if (TryCreateProvider(configuration, LevelAlias.Minimum, out var provider))
-                loggingBuilder.AddProvider(provider);
+                loggingBuilder.Services.AddSingleton<ILoggerProvider>(_ => provider);
 
             return loggingBuilder;
         }

--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -13,7 +13,7 @@
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageId>Seq.Extensions.Logging</PackageId>
     <PackageTags>asp.net;core;logging</PackageTags>
-    <PackageIconUrl>https://getseq.net/images/nuget/seq.png</PackageIconUrl>
+    <PackageIconUrl>https://datalust.co/images/nuget/seq.png</PackageIconUrl>
     <PackageProjectUrl>https://github.com/datalust/seq-extensions-logging</PackageProjectUrl>
     <PackageLicenseUrl>http://www.apache.org/licenses/LICENSE-2.0</PackageLicenseUrl>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
@@ -31,6 +31,7 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' or '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="Microsoft.Extensions.Logging" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="2.0.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' or '$(TargetFramework)' == 'net46' or '$(TargetFramework)' == 'net461'">


### PR DESCRIPTION
Switches from `LoggingBuilder.AddProvider()`'s default non-disposing `AddSingleton()` overload, to the factory-method one which ensures the resulting provider is disposed when the service collection is.