### PR TITLE
Update to latest Serilog.Sinks.PeriodicBatching and Serilog.Sinks.Seq codebases

### DIFF
--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -14,7 +14,7 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/datalust/seq-extensions-logging</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RootNamespace/>
+    <RootNamespace />
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,5 +26,4 @@
   <ItemGroup>
     <None Include="..\..\asset\icon.png" Pack="true" Visible="false" PackagePath="" />
   </ItemGroup>
-
 </Project>

--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <Description>Add centralized structured log collection to ASP.NET Core apps with one line of code.</Description>
-    <VersionPrefix>5.0.1</VersionPrefix>
+    <VersionPrefix>6.0.0</VersionPrefix>
     <Authors>Datalust and Contributors</Authors>
     <TargetFrameworks>net462;netstandard2.0;net5.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/BatchedConnectionStatus.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/BatchedConnectionStatus.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2016 Serilog Contributors
+﻿// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,7 @@ namespace Serilog.Sinks.PeriodicBatching
     /// <summary>
     /// Manages reconnection period and transient fault response for <see cref="PeriodicBatchingSink"/>.
     /// During normal operation an object of this type will simply echo the configured batch transmission
-    /// period. When availabilty fluctuates, the class tracks the number of failed attempts, each time
+    /// period. When availability fluctuates, the class tracks the number of failed attempts, each time
     /// increasing the interval before reconnection is attempted (up to a set maximum) and at predefined
     /// points indicating that either the current batch, or entire waiting queue, should be dropped. This
     /// Serves two purposes - first, a loaded receiver may need a temporary reduction in traffic while coming

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/BoundedConcurrentQueue.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2016 Serilog Contributors
+// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -18,33 +18,28 @@ using System.Threading;
 
 namespace Serilog.Sinks.PeriodicBatching
 {
-    class BoundedConcurrentQueue<T> 
+    class BoundedConcurrentQueue<T>
     {
-        const int NON_BOUNDED = -1;
+        const int Unbounded = -1;
 
         readonly ConcurrentQueue<T> _queue = new ConcurrentQueue<T>();
         readonly int _queueLimit;
 
         int _counter;
 
-        public BoundedConcurrentQueue() 
+        public BoundedConcurrentQueue(int? queueLimit = null)
         {
-            _queueLimit = NON_BOUNDED;
-        }
+            if (queueLimit.HasValue && queueLimit <= 0)
+                throw new ArgumentOutOfRangeException(nameof(queueLimit), "Queue limit must be positive, or `null` to indicate unbounded.");
 
-        public BoundedConcurrentQueue(int queueLimit)
-        {
-            if (queueLimit <= 0)
-                throw new ArgumentOutOfRangeException(nameof(queueLimit), "queue limit must be positive");
-
-            _queueLimit = queueLimit;
+            _queueLimit = queueLimit ?? Unbounded;
         }
 
         public int Count => _queue.Count;
 
         public bool TryDequeue(out T item)
         {
-            if (_queueLimit == NON_BOUNDED)
+            if (_queueLimit == Unbounded)
                 return _queue.TryDequeue(out item);
 
             var result = false;
@@ -64,7 +59,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
         public bool TryEnqueue(T item)
         {
-            if (_queueLimit == NON_BOUNDED)
+            if (_queueLimit == Unbounded)
             {
                 _queue.Enqueue(item);
                 return true;

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/IBatchedLogEventSink.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/IBatchedLogEventSink.cs
@@ -1,0 +1,38 @@
+// Copyright 2013-2020 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Serilog.Events;
+
+namespace Serilog.Sinks.PeriodicBatching
+{
+    /// <summary>
+    /// Interface for targets that accept events in batches.
+    /// </summary>
+    interface IBatchedLogEventSink
+    {
+        /// <summary>
+        /// Emit a batch of log events, running asynchronously.
+        /// </summary>
+        /// <param name="batch">The batch of events to emit.</param>
+        Task EmitBatchAsync(IEnumerable<LogEvent> batch);
+
+        /// <summary>
+        /// Allows sinks to perform periodic work without requiring additional threads
+        /// or timers (thus avoiding additional flush/shut-down complexity).
+        /// </summary>
+        Task OnEmptyBatchAsync();
+    }
+}

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/PeriodicBatchingSink.cs
@@ -1,4 +1,4 @@
-﻿// Copyright 2013-2016 Serilog Contributors
+﻿// Copyright 2013-2020 Serilog Contributors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,14 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Serilog.Core;
-using Seq.Extensions.Logging;
 using Serilog.Events;
 using System.Threading;
+using Seq.Extensions.Logging;
+
+// ReSharper disable MemberCanBePrivate.Global, UnusedMember.Global, VirtualMemberNeverOverridden.Global, ClassWithVirtualMembersNeverInherited.Global
 
 namespace Serilog.Sinks.PeriodicBatching
 {
@@ -33,9 +34,17 @@ namespace Serilog.Sinks.PeriodicBatching
     /// that want to change this behavior need to either implement from scratch, or
     /// embed retry logic in the batch emitting functions.
     /// </remarks>
-    abstract class PeriodicBatchingSink : ILogEventSink, IDisposable
+    class PeriodicBatchingSink : ILogEventSink, IDisposable, IBatchedLogEventSink
     {
+        /// <summary>
+        /// Constant used with legacy constructor to indicate that the internal queue shouldn't be limited.
+        /// </summary>
+        [Obsolete("Implement `IBatchedLogEventSink` and use the `PeriodicBatchingSinkOptions` constructor.")]
+        public const int NoQueueLimit = -1;
+
+        readonly IBatchedLogEventSink _batchedLogEventSink;
         readonly int _batchSizeLimit;
+        readonly bool _eagerlyEmitFirstEvent;
         readonly BoundedConcurrentQueue<LogEvent> _queue;
         readonly BatchedConnectionStatus _status;
         readonly Queue<LogEvent> _waitingBatch = new Queue<LogEvent>();
@@ -48,29 +57,32 @@ namespace Serilog.Sinks.PeriodicBatching
         bool _started;
 
         /// <summary>
-        /// Construct a sink posting to the specified database.
+        /// Construct a <see cref="PeriodicBatchingSink"/>.
         /// </summary>
-        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period)
+        /// <param name="batchedSink">A <see cref="IBatchedLogEventSink"/> to send log event batches to. Batches and empty
+        /// batch notifications will not be sent concurrently. When the <see cref="PeriodicBatchingSink"/> is disposed,
+        /// it will dispose this object if possible.</param>
+        /// <param name="options">Options controlling behavior of the sink.</param>
+        public PeriodicBatchingSink(IBatchedLogEventSink batchedSink, PeriodicBatchingSinkOptions options)
+            : this(options)
         {
-            _batchSizeLimit = batchSizeLimit;
-            _queue = new BoundedConcurrentQueue<LogEvent>();
-            _status = new BatchedConnectionStatus(period);
-            
-            _timer = new PortableTimer(cancel => OnTick());
+            _batchedLogEventSink = batchedSink ?? throw new ArgumentNullException(nameof(batchedSink));
         }
 
-        /// <summary>
-        /// Construct a sink posting to the specified database.
-        /// </summary>
-        /// <param name="batchSizeLimit">The maximum number of events to include in a single batch.</param>
-        /// <param name="period">The time to wait between checking for event batches.</param>
-        /// <param name="queueLimit">Maximum number of events in the queue.</param>
-        protected PeriodicBatchingSink(int batchSizeLimit, TimeSpan period, int queueLimit)
-            : this(batchSizeLimit, period)
+        PeriodicBatchingSink(PeriodicBatchingSinkOptions options)
         {
-            _queue = new BoundedConcurrentQueue<LogEvent>(queueLimit);
+            if (options == null) throw new ArgumentNullException(nameof(options));
+
+            if (options.BatchSizeLimit <= 0)
+                throw new ArgumentOutOfRangeException(nameof(options), "The batch size limit must be greater than zero.");
+            if (options.Period <= TimeSpan.Zero)
+                throw new ArgumentOutOfRangeException(nameof(options), "The period must be greater than zero.");
+
+            _batchSizeLimit = options.BatchSizeLimit;
+            _queue = new BoundedConcurrentQueue<LogEvent>(options.QueueLimit);
+            _status = new BatchedConnectionStatus(options.Period);
+            _eagerlyEmitFirstEvent = options.EagerlyEmitFirstEvent;
+            _timer = new PortableTimer(cancel => OnTick());
         }
 
         void CloseAndFlush()
@@ -85,7 +97,26 @@ namespace Serilog.Sinks.PeriodicBatching
 
             _timer.Dispose();
 
-            OnTick();
+            // This is the place where SynchronizationContext.Current is unknown and can be != null
+            // so we prevent possible deadlocks here for sync-over-async downstream implementations 
+            ResetSyncContextAndWait(OnTick);
+
+            if (_batchedLogEventSink != this)
+                (_batchedLogEventSink as IDisposable)?.Dispose();
+        }
+
+        static void ResetSyncContextAndWait(Func<Task> taskFactory)
+        {
+            var prevContext = SynchronizationContext.Current;
+            SynchronizationContext.SetSynchronizationContext(null);
+            try
+            {
+                taskFactory().Wait();
+            }
+            finally
+            {
+                SynchronizationContext.SetSynchronizationContext(prevContext);
+            }
         }
 
         /// <summary>
@@ -116,42 +147,31 @@ namespace Serilog.Sinks.PeriodicBatching
         /// not both.</remarks>
         protected virtual void EmitBatch(IEnumerable<LogEvent> events)
         {
-            var prevContext = SynchronizationContext.Current;
-            SynchronizationContext.SetSynchronizationContext(null);
-            try
-            {
-                // Wait so that the timer thread stays busy and thus
-                // we know we're working when flushing.
-                EmitBatchAsync(events).Wait();
-            }
-            finally
-            {
-                SynchronizationContext.SetSynchronizationContext(prevContext);
-            }
         }
 
         /// <summary>
         /// Emit a batch of log events, running asynchronously.
         /// </summary>
         /// <param name="events">The events to emit.</param>
-        /// <remarks>Override either <see cref="EmitBatch"/> or <see cref="EmitBatchAsync"/>,
-        /// not both. Overriding EmitBatch() is preferred.</remarks>
+        /// <remarks>Override either <see cref="EmitBatchAsync"/> or <see cref="EmitBatch"/>,
+        /// not both. </remarks>
 #pragma warning disable 1998
         protected virtual async Task EmitBatchAsync(IEnumerable<LogEvent> events)
 #pragma warning restore 1998
         {
+            // ReSharper disable once MethodHasAsyncOverload
+            EmitBatch(events);
         }
 
-        void OnTick()
+        async Task OnTick()
         {
             try
             {
                 bool batchWasFull;
                 do
                 {
-                    LogEvent next;
                     while (_waitingBatch.Count < _batchSizeLimit &&
-                        _queue.TryDequeue(out next))
+                           _queue.TryDequeue(out var next))
                     {
                         if (CanInclude(next))
                             _waitingBatch.Enqueue(next);
@@ -159,11 +179,11 @@ namespace Serilog.Sinks.PeriodicBatching
 
                     if (_waitingBatch.Count == 0)
                     {
-                        OnEmptyBatch();
+                        await _batchedLogEventSink.OnEmptyBatchAsync();
                         return;
                     }
 
-                    EmitBatch(_waitingBatch);
+                    await _batchedLogEventSink.EmitBatchAsync(_waitingBatch);
 
                     batchWasFull = _waitingBatch.Count >= _batchSizeLimit;
                     _waitingBatch.Clear();
@@ -183,8 +203,7 @@ namespace Serilog.Sinks.PeriodicBatching
 
                 if (_status.ShouldDropQueue)
                 {
-                    LogEvent evt;
-                    while (_queue.TryDequeue(out evt)) { }
+                    while (_queue.TryDequeue(out _)) { }
                 }
 
                 lock (_stateLock)
@@ -225,11 +244,20 @@ namespace Serilog.Sinks.PeriodicBatching
                     if (_unloading) return;
                     if (!_started)
                     {
-                        // Special handling to try to get the first event across as quickly
-                        // as possible to show we're alive!
                         _queue.TryEnqueue(logEvent);
                         _started = true;
-                        SetTimer(TimeSpan.Zero);
+
+                        if (_eagerlyEmitFirstEvent)
+                        {
+                            // Special handling to try to get the first event across as quickly
+                            // as possible to show we're alive!
+                            SetTimer(TimeSpan.Zero);
+                        }
+                        else
+                        {
+                            SetTimer(_status.NextInterval);
+                        }
+
                         return;
                     }
                 }
@@ -242,9 +270,10 @@ namespace Serilog.Sinks.PeriodicBatching
         /// Determine whether a queued log event should be included in the batch. If
         /// an override returns false, the event will be dropped.
         /// </summary>
-        /// <param name="evt"></param>
-        /// <returns></returns>
-        protected virtual bool CanInclude(LogEvent evt)
+        /// <param name="logEvent">An event to test for inclusion.</param>
+        /// <returns>True if the event should be included in the batch; otherwise, false.</returns>
+        // ReSharper disable once UnusedParameter.Global
+        protected virtual bool CanInclude(LogEvent logEvent)
         {
             return true;
         }
@@ -253,8 +282,27 @@ namespace Serilog.Sinks.PeriodicBatching
         /// Allows derived sinks to perform periodic work without requiring additional threads
         /// or timers (thus avoiding additional flush/shut-down complexity).
         /// </summary>
+        /// <remarks>Override either <see cref="OnEmptyBatch"/> or <see cref="OnEmptyBatchAsync"/>,
+        /// not both. </remarks>
         protected virtual void OnEmptyBatch()
         {
         }
+
+        /// <summary>
+        /// Allows derived sinks to perform periodic work without requiring additional threads
+        /// or timers (thus avoiding additional flush/shut-down complexity).
+        /// </summary>
+        /// <remarks>Override either <see cref="OnEmptyBatchAsync"/> or <see cref="OnEmptyBatch"/>,
+        /// not both. </remarks>
+#pragma warning disable 1998
+        protected virtual async Task OnEmptyBatchAsync()
+#pragma warning restore 1998
+        {
+            // ReSharper disable once MethodHasAsyncOverload
+            OnEmptyBatch();
+        }
+        
+        Task IBatchedLogEventSink.EmitBatchAsync(IEnumerable<LogEvent> batch) => EmitBatchAsync(batch);
+        Task IBatchedLogEventSink.OnEmptyBatchAsync() => OnEmptyBatchAsync();
     }
 }

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/PeriodicBatchingSinkOptions.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/PeriodicBatching/PeriodicBatchingSinkOptions.cs
@@ -1,0 +1,47 @@
+// Copyright 2013-2020 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Serilog.Sinks.PeriodicBatching
+{
+    /// <summary>
+    /// Initialization options for <see cref="PeriodicBatchingSink"/>.
+    /// </summary>
+    class PeriodicBatchingSinkOptions
+    {
+        /// <summary>
+        /// Eagerly emit a batch containing the first received event, regardless of
+        /// the target batch size or batching time. This helps with perceived "liveness"
+        /// when running/debugging applications interactively. The default is <c>true</c>.
+        /// </summary>
+        public bool EagerlyEmitFirstEvent { get; set; } = true;
+
+        /// <summary>
+        /// The maximum number of events to include in a single batch. The default is <c>1000</c>.
+        /// </summary>
+        public int BatchSizeLimit { get; set; } = 1000;
+
+        /// <summary>
+        /// The time to wait between checking for event batches. The default is two seconds.
+        /// </summary>
+        public TimeSpan Period { get; set; } = TimeSpan.FromSeconds(2);
+
+        /// <summary>
+        /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
+        /// for an unbounded queue. The default is <c>100000</c>.
+        /// </summary>
+        public int? QueueLimit { get; set; } = 100000;
+    }
+}

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/ExponentialBackoffConnectionSchedule.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/ExponentialBackoffConnectionSchedule.cs
@@ -1,0 +1,76 @@
+﻿// Serilog.Sinks.Seq Copyright 2016 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+
+namespace Serilog.Sinks.Seq
+{
+    /// <summary>
+    /// Based on the BatchedConnectionStatus class from <see cref="Serilog.Sinks.PeriodicBatching.PeriodicBatchingSink"/>.
+    /// </summary>
+    class ExponentialBackoffConnectionSchedule
+    {
+        static readonly TimeSpan MinimumBackoffPeriod = TimeSpan.FromSeconds(5);
+        static readonly TimeSpan MaximumBackoffInterval = TimeSpan.FromMinutes(10);
+
+        readonly TimeSpan _period;
+
+        int _failuresSinceSuccessfulConnection;
+
+        public ExponentialBackoffConnectionSchedule(TimeSpan period)
+        {
+            if (period < TimeSpan.Zero) throw new ArgumentOutOfRangeException(nameof(period), "The connection retry period must be a positive timespan");
+       
+            _period = period;
+        }
+
+        public void MarkSuccess()
+        {
+            _failuresSinceSuccessfulConnection = 0;
+        }
+
+        public void MarkFailure()
+        {
+            ++_failuresSinceSuccessfulConnection;
+        }
+
+        public TimeSpan NextInterval
+        {
+            get
+            {
+                // Available, and first failure, just try the batch interval
+                if (_failuresSinceSuccessfulConnection <= 1) return _period;
+
+                // Second failure, start ramping up the interval - first 2x, then 4x, ...
+                var backoffFactor = Math.Pow(2, (_failuresSinceSuccessfulConnection - 1));
+
+                // If the period is ridiculously short, give it a boost so we get some
+                // visible backoff.
+                var backoffPeriod = Math.Max(_period.Ticks, MinimumBackoffPeriod.Ticks);
+
+                // The "ideal" interval
+                var backedOff = (long)(backoffPeriod * backoffFactor);
+
+                // Capped to the maximum interval
+                var cappedBackoff = Math.Min(MaximumBackoffInterval.Ticks, backedOff);
+
+                // Unless that's shorter than the base interval, in which case we'll just apply the period
+                var actual = Math.Max(_period.Ticks, cappedBackoff);
+
+                return TimeSpan.FromTicks(actual);
+            }
+        }
+    }
+}
+

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqApi.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqApi.cs
@@ -48,7 +48,13 @@ namespace Serilog.Sinks.Seq
                 return null;
 
             var value = eventInputResult.Substring(startValue, endValue - startValue);
-            if (!Enum.TryParse(value, out LogLevel minimumLevel))
+            
+            LogLevel minimumLevel;
+            if (value == "Verbose")
+                minimumLevel = LogLevel.Trace;
+            else if (value == "Fatal")
+                minimumLevel = LogLevel.Critical;
+            else if (!Enum.TryParse(value, out minimumLevel))
                 return null;
 
             return minimumLevel;

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqApi.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqApi.cs
@@ -13,16 +13,14 @@
 // limitations under the License.
 
 using System;
-using Serilog.Events;
 using Microsoft.Extensions.Logging;
 
 namespace Serilog.Sinks.Seq
 {
-    class SeqApi
+    static class SeqApi
     {
         public const string BulkUploadResource = "api/events/raw";
         public const string ApiKeyHeaderName = "X-Seq-ApiKey";
-        public const string RawEventFormatMimeType = "application/json";
         public const string CompactLogEventFormatMimeType = "application/vnd.serilog.clef";
 
         // Why not use a JSON parser here? For a very small case, it's not
@@ -35,8 +33,8 @@ namespace Serilog.Sinks.Seq
         {
             if (eventInputResult == null) return null;
 
-            // Seq 1.5 servers will return JSON including "MinimumLevelAccepted":x, where
-            // x may be null or a JSON string representation of the equivalent LogLevel
+            // Seq servers will return JSON including "MinimumLevelAccepted":x, where
+            // x may be null or a JSON string representation of the equivalent LogEventLevel
             var startProp = eventInputResult.IndexOf(LevelMarker, StringComparison.Ordinal);
             if (startProp == -1)
                 return null;
@@ -50,12 +48,7 @@ namespace Serilog.Sinks.Seq
                 return null;
 
             var value = eventInputResult.Substring(startValue, endValue - startValue);
-            LogLevel minimumLevel;
-            if (value == "Verbose")
-                minimumLevel = LogLevel.Trace;
-            else if (value == "Fatal")
-                minimumLevel = LogLevel.Critical;
-            else if (!Enum.TryParse(value, out minimumLevel))
+            if (!Enum.TryParse(value, out LogLevel minimumLevel))
                 return null;
 
             return minimumLevel;

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqPayloadFormatter.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqPayloadFormatter.cs
@@ -1,0 +1,80 @@
+// Serilog.Sinks.Seq Copyright 2014-2019 Serilog Contributors
+// 
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+// 
+//     http://www.apache.org/licenses/LICENSE-2.0
+// 
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using Seq.Extensions.Logging;
+using Serilog.Events;
+using Serilog.Formatting.Compact;
+using Serilog.Formatting.Json;
+
+namespace Serilog.Sinks.Seq
+{
+    static class SeqPayloadFormatter
+    {
+        static readonly JsonValueFormatter JsonValueFormatter = new JsonValueFormatter("$type");
+        
+        public static string FormatCompactPayload(IEnumerable<LogEvent> events, long? eventBodyLimitBytes)
+        {
+            var payload = new StringWriter();
+
+            foreach (var logEvent in events)
+            {
+                var buffer = new StringWriter();
+
+                try
+                {
+                    CompactJsonFormatter.FormatEvent(logEvent, buffer, JsonValueFormatter);
+                }
+                catch (Exception ex)
+                {
+                    LogNonFormattableEvent(logEvent, ex);
+                    continue;
+                }
+
+                var json = buffer.ToString();
+                if (CheckEventBodySize(json, eventBodyLimitBytes))
+                {
+                    payload.WriteLine(json);
+                }
+            }
+
+            return payload.ToString();
+        }
+
+        static void LogNonFormattableEvent(LogEvent logEvent, Exception ex)
+        {
+            SelfLog.WriteLine(
+                "Event at {0} with message template {1} could not be formatted into JSON for Seq and will be dropped: {2}",
+                logEvent.Timestamp.ToString("o"), logEvent.MessageTemplate.Text, ex);
+        }
+
+        static bool CheckEventBodySize(string json, long? eventBodyLimitBytes)
+        {
+            if (eventBodyLimitBytes.HasValue &&
+                Encoding.UTF8.GetByteCount(json) > eventBodyLimitBytes.Value)
+            {
+                SelfLog.WriteLine(
+                    "Event JSON representation exceeds the byte size limit of {0} set for this Seq sink and will be dropped; data: {1}",
+                    eventBodyLimitBytes, json);
+                return false;
+            }
+
+            return true;
+        }
+
+    }
+}


### PR DESCRIPTION
 * Uses the `System.Threading.Timer`-based variant of `PortableTimer`
 * Drops support for Seq versions < 3.3 (ancient history, at this point)

Fixes #40