### PR TITLE
Introduce `JsonSafeString`

### DIFF
--- a/Build.ps1
+++ b/Build.ps1
@@ -21,9 +21,9 @@ foreach ($src in ls src/*) {
     echo "build: Packaging project in $src"
 
     if ($suffix) {
-        & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix --include-source
+        & dotnet pack -c Release -o ..\..\artifacts --version-suffix=$suffix
     } else {
-        & dotnet pack -c Release -o ..\..\artifacts --include-source
+        & dotnet pack -c Release -o ..\..\artifacts
     }
     
     if($LASTEXITCODE -ne 0) { exit 1 }    

--- a/README.md
+++ b/README.md
@@ -105,6 +105,15 @@ In `appsettings.json` add a `"Seq"` property to `"Logging"` to configure the ser
 The logging provider will dynamically adjust the default logging level up or down based on the level associated with an API key in Seq. For further information see 
 the [Seq documentation](http://docs.datalust.co/docs/using-serilog#dynamic-level-control).
 
+### Including literal JSON strings in log events
+
+The logging provider ships with a `JsonSafeString` type that can be used to communicate to the logger that a string contains valid JSON, which can be safely included in a log event as structured data.
+
+```csharp
+var json = "{\"A\": 42}";
+_logger.LogInformation("The answer is {Answer}", new JsonSafeString(json));
+```
+
 ### Troubleshooting
 
 > Nothing showed up, what can I do?

--- a/seq-extensions-logging.sln
+++ b/seq-extensions-logging.sln
@@ -1,5 +1,4 @@
-﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+﻿Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29326.143
 MinimumVisualStudioVersion = 10.0.40219.1

--- a/seq-extensions-logging.sln.DotSettings
+++ b/seq-extensions-logging.sln.DotSettings
@@ -3,4 +3,5 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -14,10 +14,12 @@
     <PackageIcon>icon.png</PackageIcon>
     <PackageProjectUrl>https://github.com/datalust/seq-extensions-logging</PackageProjectUrl>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+    <LangVersion>latest</LangVersion>
     <RootNamespace />
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="5.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="5.0.0" />

--- a/src/Seq.Extensions.Logging/Seq/Extensions/Logging/JsonSafeString.cs
+++ b/src/Seq.Extensions.Logging/Seq/Extensions/Logging/JsonSafeString.cs
@@ -1,0 +1,30 @@
+﻿#nullable enable
+
+namespace Seq.Extensions.Logging
+{
+    /// <summary>
+    /// A wrapper type that marks a string as containing valid JSON that's safe to include as-is in log events.
+    /// </summary>
+    public readonly struct JsonSafeString
+    {
+        string? Json { get; }
+
+        /// <summary>
+        /// Construct a <see cref="JsonSafeString"/> with well-formed JSON. The JSON is not validated: it must be
+        /// externally validated or proven to be valid JSON before calling this constructor.
+        /// </summary>
+        /// <param name="json">A well-formed JSON string that can be included directly in a log event.</param>
+        public JsonSafeString(string json)
+        {
+            Json = json;
+        }
+
+        /// <inheritdoc />
+        public override string ToString()
+        {
+            // As this type is a struct, it's impossible to enforce that `Json` is non-null. We use "<null>" instead
+            // of a literal JSON null, so that valid null values can be distinguished from invalid values.
+            return Json ?? "\"<null>\"";
+        }
+    }
+}

--- a/src/Seq.Extensions.Logging/Seq/Extensions/Logging/SelfLog.cs
+++ b/src/Seq.Extensions.Logging/Seq/Extensions/Logging/SelfLog.cs
@@ -26,25 +26,6 @@ namespace Seq.Extensions.Logging
         static Action<string> _output;
 
         /// <summary>
-        /// The output mechanism for self-log messages.
-        /// </summary>
-        /// <example>
-        /// SelfLog.Out = Console.Error;
-        /// </example>
-        // ReSharper disable once MemberCanBePrivate.Global, UnusedAutoPropertyAccessor.Global
-        [Obsolete("Use SelfLog.Enable(value) and SelfLog.Disable() instead")]
-        public static TextWriter Out
-        {
-            set
-            {
-                if (value != null)
-                    Enable(value);
-                else
-                    Disable();
-            }
-        }
-
-        /// <summary>
         /// Set the output mechanism for self-log messages.
         /// </summary>
         /// <param name="output">A synchronized <see cref="TextWriter"/> to which
@@ -68,8 +49,7 @@ namespace Seq.Extensions.Logging
         /// // ReSharper disable once MemberCanBePrivate.Global
         public static void Enable(Action<string> output)
         {
-            if (output == null) throw new ArgumentNullException(nameof(output));
-            _output = output;
+            _output = output ?? throw new ArgumentNullException(nameof(output));
         }
 
         /// <summary>

--- a/src/Seq.Extensions.Logging/Serilog/Formatting/Compact/CompactJsonFormatter.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Formatting/Compact/CompactJsonFormatter.cs
@@ -22,31 +22,8 @@ using Microsoft.Extensions.Logging;
 
 namespace Serilog.Formatting.Compact
 {
-    class CompactJsonFormatter
+    static class CompactJsonFormatter
     {
-        readonly JsonValueFormatter _valueFormatter;
-
-        /// <summary>
-        /// Construct a <see cref="CompactJsonFormatter"/>, optionally supplying a formatter for
-        /// <see cref="LogEventPropertyValue"/>s on the event.
-        /// </summary>
-        /// <param name="valueFormatter">A value formatter, or null.</param>
-        public CompactJsonFormatter(JsonValueFormatter valueFormatter = null)
-        {
-            _valueFormatter = valueFormatter ?? new JsonValueFormatter(typeTagName: "$type");
-        }
-
-        /// <summary>
-        /// Format the log event into the output. Subsequent events will be newline-delimited.
-        /// </summary>
-        /// <param name="logEvent">The event to format.</param>
-        /// <param name="output">The output.</param>
-        public void Format(LogEvent logEvent, TextWriter output)
-        {
-            FormatEvent(logEvent, output, _valueFormatter);
-            output.WriteLine();
-        }
-
         /// <summary>
         /// Format the log event into the output.
         /// </summary>

--- a/src/Seq.Extensions.Logging/Serilog/Formatting/Json/JsonValueFormatter.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Formatting/Json/JsonValueFormatter.cs
@@ -222,6 +222,7 @@ namespace Serilog.Formatting.Json
             if (value is JsonSafeString jss)
             {
                 FormatJsonSafeString(jss, output);
+                return;
             }
 
             FormatLiteralObjectValue(value, output);

--- a/src/Seq.Extensions.Logging/Serilog/Formatting/Json/JsonValueFormatter.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Formatting/Json/JsonValueFormatter.cs
@@ -15,8 +15,10 @@
 using System;
 using System.Globalization;
 using System.IO;
+using Seq.Extensions.Logging;
 using Serilog.Data;
 using Serilog.Events;
+// ReSharper disable ForCanBeConvertedToForeach
 
 namespace Serilog.Formatting.Json
 {
@@ -152,7 +154,7 @@ namespace Serilog.Formatting.Json
         /// </summary>
         /// <param name="value">The value to write.</param>
         /// <param name="output">The output</param>
-        protected virtual void FormatLiteralValue(object value, TextWriter output)
+        static void FormatLiteralValue(object value, TextWriter output)
         {
             if (value == null)
             {
@@ -163,11 +165,10 @@ namespace Serilog.Formatting.Json
             // Although the linear switch-on-type has apparently worse algorithmic performance than the O(1)
             // dictionary lookup alternative, in practice, it's much to make a few equality comparisons
             // than the hash/bucket dictionary lookup, and since most data will be string (one comparison),
-            // numeric (a handful) or an object (two comparsions) the real-world performance of the code
+            // numeric (a handful) or an object (two comparisons) the real-world performance of the code
             // as written is as fast or faster.
 
-            var str = value as string;
-            if (str != null)
+            if (value is string str)
             {
                 FormatStringValue(str, output);
                 return;
@@ -175,28 +176,27 @@ namespace Serilog.Formatting.Json
 
             if (value is ValueType)
             {
-                if (value is int || value is uint || value is long || value is ulong || value is decimal ||
-                    value is byte || value is sbyte || value is short || value is ushort)
+                if (value is int or uint or long or ulong or decimal or byte or sbyte or short or ushort)
                 {
                     FormatExactNumericValue((IFormattable)value, output);
                     return;
                 }
 
-                if (value is double)
+                if (value is double d)
                 {
-                    FormatDoubleValue((double)value, output);
+                    FormatDoubleValue(d, output);
                     return;
                 }
 
-                if (value is float)
+                if (value is float f)
                 {
-                    FormatFloatValue((float)value, output);
+                    FormatFloatValue(f, output);
                     return;
                 }
 
-                if (value is bool)
+                if (value is bool b)
                 {
-                    FormatBooleanValue((bool)value, output);
+                    FormatBooleanValue(b, output);
                     return;
                 }
 
@@ -206,20 +206,30 @@ namespace Serilog.Formatting.Json
                     return;
                 }
 
-                if (value is DateTime || value is DateTimeOffset)
+                if (value is DateTime or DateTimeOffset)
                 {
                     FormatDateTimeValue((IFormattable)value, output);
                     return;
                 }
 
-                if (value is TimeSpan)
+                if (value is TimeSpan span)
                 {
-                    FormatTimeSpanValue((TimeSpan)value, output);
+                    FormatTimeSpanValue(span, output);
                     return;
                 }
             }
 
+            if (value is JsonSafeString jss)
+            {
+                FormatJsonSafeString(jss, output);
+            }
+
             FormatLiteralObjectValue(value, output);
+        }
+
+        static void FormatJsonSafeString(JsonSafeString jss, TextWriter output)
+        {
+            output.Write(jss.ToString());
         }
 
         static void FormatBooleanValue(bool value, TextWriter output)

--- a/src/Seq.Extensions.Logging/Serilog/Parsing/PropertyToken.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Parsing/PropertyToken.cs
@@ -35,20 +35,6 @@ namespace Serilog.Parsing
         /// </summary>
         /// <param name="propertyName">The name of the property.</param>
         /// <param name="rawText">The token as it appears in the message template.</param>
-        /// <param name="formatObsolete">The format applied to the property, if any.</param>
-        /// <param name="destructuringObsolete">The destructuring strategy applied to the property, if any.</param>
-        /// <exception cref="ArgumentNullException"></exception>
-        [Obsolete("Use named arguments with this method to guarantee forwards-compatibility."), EditorBrowsable(EditorBrowsableState.Never)]
-        public PropertyToken(string propertyName, string rawText, string formatObsolete, Destructuring destructuringObsolete)
-            : this(propertyName, rawText, formatObsolete, null, destructuringObsolete)
-        {
-        }
-
-        /// <summary>
-        /// Construct a <see cref="PropertyToken"/>.
-        /// </summary>
-        /// <param name="propertyName">The name of the property.</param>
-        /// <param name="rawText">The token as it appears in the message template.</param>
         /// <param name="format">The format applied to the property, if any.</param>
         /// <param name="alignment">The alignment applied to the property, if any.</param>
         /// <param name="destructuring">The destructuring strategy applied to the property, if any.</param>
@@ -57,16 +43,13 @@ namespace Serilog.Parsing
         public PropertyToken(string propertyName, string rawText, string format = null, Alignment? alignment = null, Destructuring destructuring = Destructuring.Default, int startIndex = -1)
             : base(startIndex)
         {
-            if (propertyName == null) throw new ArgumentNullException(nameof(propertyName));
-            if (rawText == null) throw new ArgumentNullException(nameof(rawText));
-            PropertyName = propertyName;
+            PropertyName = propertyName ?? throw new ArgumentNullException(nameof(propertyName));
             Format = format;
             Destructuring = destructuring;
-            _rawText = rawText;
+            _rawText = rawText ?? throw new ArgumentNullException(nameof(rawText));
             Alignment = alignment;
 
-            int position;
-            if (int.TryParse(PropertyName, NumberStyles.None, CultureInfo.InvariantCulture, out position) &&
+            if (int.TryParse(PropertyName, NumberStyles.None, CultureInfo.InvariantCulture, out var position) &&
                 position >= 0)
             {
                 _position = position;
@@ -89,8 +72,7 @@ namespace Serilog.Parsing
             if (properties == null) throw new ArgumentNullException(nameof(properties));
             if (output == null) throw new ArgumentNullException(nameof(output));
 
-            LogEventPropertyValue propertyValue;
-            if (!properties.TryGetValue(PropertyName, out propertyValue))
+            if (!properties.TryGetValue(PropertyName, out var propertyValue))
             {
                 output.Write(_rawText);
                 return;
@@ -166,12 +148,11 @@ namespace Serilog.Parsing
         /// <param name="obj">The object to compare with the current object. </param><filterpriority>2</filterpriority>
         public override bool Equals(object obj)
         {
-            var pt = obj as PropertyToken;
-            return pt != null &&
-                pt.Destructuring == Destructuring &&
-                pt.Format == Format &&
-                pt.PropertyName == PropertyName &&
-                pt._rawText == _rawText;
+            return obj is PropertyToken pt &&
+                   pt.Destructuring == Destructuring &&
+                   pt.Format == Format &&
+                   pt.PropertyName == PropertyName &&
+                   pt._rawText == _rawText;
         }
 
         /// <summary>

--- a/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqPayloadFormatter.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Sinks/Seq/SeqPayloadFormatter.cs
@@ -25,7 +25,7 @@ namespace Serilog.Sinks.Seq
 {
     static class SeqPayloadFormatter
     {
-        static readonly JsonValueFormatter JsonValueFormatter = new JsonValueFormatter("$type");
+        static readonly JsonValueFormatter JsonValueFormatter = new("$type");
         
         public static string FormatCompactPayload(IEnumerable<LogEvent> events, long? eventBodyLimitBytes)
         {

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/SeqPayloadFormatterTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/SeqPayloadFormatterTests.cs
@@ -1,0 +1,26 @@
+﻿using Serilog.Sinks.Seq;
+using Tests.Support;
+using Xunit;
+
+namespace Seq.Extensions.Logging.Tests.Serilog.Sinks.Seq
+{
+    public class SeqPayloadFormatterTests
+    {
+        [Fact]
+        public void JsonSafeStringPropertiesAreIncludedAsIs()
+        {
+            const string json = "{\"A\": 42}";
+            var evt = Some.LogEvent("The answer is {Answer}", new JsonSafeString(json));
+            var payload = SeqPayloadFormatter.FormatCompactPayload(new[] { evt }, null);
+            Assert.Contains("\"Answer\":{\"A\": 42}", payload);
+        }
+        
+        [Fact]
+        public void DefaultJsonSafeStringsDoNotCorruptPayload()
+        {
+            var evt = Some.LogEvent("The answer is {Answer}", (JsonSafeString)default);
+            var payload = SeqPayloadFormatter.FormatCompactPayload(new[] { evt }, null);
+            Assert.Contains("\"Answer\":\"<null>\"", payload);
+        }
+    }
+}


### PR DESCRIPTION
Fixes #46

Since no serialization actually occurs, the PR proposes to do this without relying on the `@` operator that the original ticket describes.

`JsonSafeString` can be passed anywhere that property values are accepted (including through `BeginScope()`).

### Usage

```csharp
var json = "{\"A\": 42}";
_logger.LogInformation("The answer is {Answer}", new JsonSafeString(json));
```

### Result

![image](https://user-images.githubusercontent.com/342712/182291557-623cc819-e0d6-4731-8364-a02c44eb4b0f.png)
