### PR TITLE
Capture `Activity` trace and span ids when present

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,18 @@ var json = "{\"A\": 42}";
 _logger.LogInformation("The answer is {Answer}", new JsonSafeString(json));
 ```
 
+### Trace and span correlation
+
+The Seq logger provider automatically adds trace and span ids to events when present, enabling the _Trace_ drop-down menu in Seq's expanded event view.
+
+ASP.NET Core may add additional top-level `TraceId`, `SpanId`, and `ParentId` properties in its default configuration. You can remove these if you wish, using `ILoggingBuilder.Configure()`:
+
+```csharp
+builder.Logging.Configure(opts => {
+    opts.ActivityTrackingOptions = ActivityTrackingOptions.None;
+});
+```
+
 ### Troubleshooting
 
 > Nothing showed up, what can I do?

--- a/example/WebExample/Controllers/HomeController.cs
+++ b/example/WebExample/Controllers/HomeController.cs
@@ -6,7 +6,7 @@ namespace WebExample.Controllers;
 
 public class HomeController : Controller
 {
-    private readonly ILogger<HomeController> _logger;
+    readonly ILogger<HomeController> _logger;
 
     public HomeController(ILogger<HomeController> logger)
     {

--- a/example/WebExample/Program.cs
+++ b/example/WebExample/Program.cs
@@ -6,6 +6,10 @@ builder.Services.AddControllersWithViews();
 // Use the Seq logging configuration in appsettings.json
 builder.Logging.AddSeq();
 
+// Don't log redundant top-level `TraceId` and `SpanId` properties, these are handled implicitly
+// by the Seq logger.
+builder.Logging.Configure(opts => opts.ActivityTrackingOptions = ActivityTrackingOptions.None);
+
 var app = builder.Build();
 
 // Configure the HTTP request pipeline.

--- a/example/WebExample/Program.cs
+++ b/example/WebExample/Program.cs
@@ -4,8 +4,7 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddControllersWithViews();
 
 // Use the Seq logging configuration in appsettings.json
-builder.Host.ConfigureLogging(loggingBuilder =>
-    loggingBuilder.AddSeq());
+builder.Logging.AddSeq();
 
 var app = builder.Build();
 

--- a/seq-extensions-logging.sln.DotSettings
+++ b/seq-extensions-logging.sln.DotSettings
@@ -2,6 +2,7 @@
 	<s:String x:Key="/Default/CodeStyle/Naming/CSharpNaming/PredefinedNamingRules/=PrivateInstanceFields/@EntryIndexedValue">&lt;Policy Inspect="True" Prefix="_" Suffix="" Style="aaBb"&gt;&lt;ExtraRule Prefix="" Suffix="" Style="AaBb" /&gt;&lt;/Policy&gt;</s:String>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=appsettings/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Datalust/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Destructurer/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Enricher/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formattable/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Serilog/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/Seq.Extensions.Logging/Serilog/Events/LevelAlias.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Events/LevelAlias.cs
@@ -28,9 +28,4 @@ static class LevelAlias
     /// The least significant level of event.
     /// </summary>
     public const LogLevel Minimum = LogLevel.Trace;
-
-    /// <summary>
-    /// The most significant level of event.
-    /// </summary>
-    public const LogLevel Maximum = LogLevel.Critical;
 }

--- a/src/Seq.Extensions.Logging/Serilog/Events/LogEvent.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Events/LogEvent.cs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 
 namespace Serilog.Events;
@@ -22,6 +23,8 @@ namespace Serilog.Events;
 class LogEvent
 {
     readonly Dictionary<string, LogEventPropertyValue> _properties;
+    ActivityTraceId _traceId;
+    ActivitySpanId _spanId;
 
     /// <summary>
     /// Construct a new <seealso cref="LogEvent"/>.
@@ -31,14 +34,24 @@ class LogEvent
     /// <param name="exception">An exception associated with the event, or null.</param>
     /// <param name="messageTemplate">The message template describing the event.</param>
     /// <param name="properties">Properties associated with the event, including those presented in <paramref name="messageTemplate"/>.</param>
-    public LogEvent(DateTimeOffset timestamp, LogLevel level, Exception exception, MessageTemplate messageTemplate, IEnumerable<LogEventProperty> properties)
+    /// <param name="traceId">The id of the trace that was active when the event was created, if any.</param>
+    /// <param name="spanId">The id of the span that was active when the event was created, if any.</param>
+    public LogEvent(
+        DateTimeOffset timestamp, 
+        LogLevel level, 
+        Exception exception, 
+        MessageTemplate messageTemplate,
+        IEnumerable<LogEventProperty> properties,
+        ActivityTraceId traceId,
+        ActivitySpanId spanId)
     {
-        if (messageTemplate == null) throw new ArgumentNullException(nameof(messageTemplate));
         if (properties == null) throw new ArgumentNullException(nameof(properties));
+        _traceId = traceId;
+        _spanId = spanId;
         Timestamp = timestamp;
         Level = level;
         Exception = exception;
-        MessageTemplate = messageTemplate;
+        MessageTemplate = messageTemplate ?? throw new ArgumentNullException(nameof(messageTemplate));
         _properties = new Dictionary<string, LogEventPropertyValue>();
         foreach (var p in properties)
             AddOrUpdateProperty(p);
@@ -53,6 +66,18 @@ class LogEvent
     /// The level of the event.
     /// </summary>
     public LogLevel Level { get; }
+
+    /// <summary>
+    /// The id of the trace that was active when the event was created, if any.
+    /// </summary>
+    [CLSCompliant(false)]
+    public ActivityTraceId? TraceId => _traceId == default ? null : _traceId;
+
+    /// <summary>
+    /// The id of the span that was active when the event was created, if any.
+    /// </summary>
+    [CLSCompliant(false)]
+    public ActivitySpanId? SpanId => _spanId == default ? null : _spanId;
 
     /// <summary>
     /// The message template describing the event.

--- a/src/Seq.Extensions.Logging/Serilog/Events/LogEvent.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Events/LogEvent.cs
@@ -37,9 +37,9 @@ class LogEvent
     /// <param name="traceId">The id of the trace that was active when the event was created, if any.</param>
     /// <param name="spanId">The id of the span that was active when the event was created, if any.</param>
     public LogEvent(
-        DateTimeOffset timestamp, 
-        LogLevel level, 
-        Exception exception, 
+        DateTimeOffset timestamp,
+        LogLevel level,
+        Exception exception,
         MessageTemplate messageTemplate,
         IEnumerable<LogEventProperty> properties,
         ActivityTraceId traceId,
@@ -70,13 +70,11 @@ class LogEvent
     /// <summary>
     /// The id of the trace that was active when the event was created, if any.
     /// </summary>
-    [CLSCompliant(false)]
     public ActivityTraceId? TraceId => _traceId == default ? null : _traceId;
 
     /// <summary>
     /// The id of the span that was active when the event was created, if any.
     /// </summary>
-    [CLSCompliant(false)]
     public ActivitySpanId? SpanId => _spanId == default ? null : _spanId;
 
     /// <summary>

--- a/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLogger.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLogger.cs
@@ -44,7 +44,7 @@ class SerilogLogger : FrameworkLogger
         return _logger.IsEnabled(logLevel);
     }
 
-    public IDisposable? BeginScope<TState>(TState state) where TState: notnull
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull
     {
         return _provider.BeginScope(state);
     }

--- a/src/Seq.Extensions.Logging/Serilog/Formatting/Compact/CompactJsonFormatter.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Formatting/Compact/CompactJsonFormatter.cs
@@ -16,6 +16,7 @@ using Serilog.Events;
 using Serilog.Formatting.Json;
 using Serilog.Parsing;
 using Microsoft.Extensions.Logging;
+// ReSharper disable PossibleMultipleEnumeration
 
 namespace Serilog.Formatting.Compact;
 
@@ -70,6 +71,20 @@ static class CompactJsonFormatter
         {
             output.Write(",\"@x\":");
             JsonValueFormatter.WriteQuotedJsonString(logEvent.Exception.ToString(), output);
+        }
+
+        if (logEvent.TraceId != null)
+        {
+            output.Write(",\"@tr\":\"");
+            output.Write(logEvent.TraceId.Value.ToHexString());
+            output.Write('\"');
+        }
+
+        if (logEvent.SpanId != null)
+        {
+            output.Write(",\"@sp\":\"");
+            output.Write(logEvent.SpanId.Value.ToHexString());
+            output.Write('\"');
         }
 
         foreach (var property in logEvent.Properties)

--- a/src/Seq.Extensions.Logging/Serilog/Parameters/PropertyValueConverter.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Parameters/PropertyValueConverter.cs
@@ -196,7 +196,7 @@ partial class PropertyValueConverter : ILogEventPropertyFactory, ILogEventProper
         return new ScalarValue(value.ToString());
     }
 
-    private LogEventPropertyValue Stringify(object value)
+    LogEventPropertyValue Stringify(object value)
     {
         var stringified = value.ToString();
         var truncated = TruncateIfNecessary(stringified);

--- a/test/Seq.Extensions.Logging.Tests/Seq.Extensions.Logging.Tests.csproj
+++ b/test/Seq.Extensions.Logging.Tests/Seq.Extensions.Logging.Tests.csproj
@@ -5,6 +5,8 @@
     <AssemblyOriginatorKeyFile>../../asset/seqext.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+    <RootNamespace>Tests</RootNamespace>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,6 +20,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/test/Seq.Extensions.Logging.Tests/Seq/Extensions/Logging/ExceptionDataEnricherTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Seq/Extensions/Logging/ExceptionDataEnricherTests.cs
@@ -5,46 +5,45 @@ using System.Linq;
 using Tests.Support;
 using Xunit;
 
-namespace Tests.Seq.Extensions.Logging
+namespace Tests.Seq.Extensions.Logging;
+
+public class ExceptionDataEnricherTests
 {
-    public class ExceptionDataEnricherTests
+    [Fact]
+    public void WhenNoDataIsPresentNoPropertyIsAdded()
     {
-        [Fact]
-        public void WhenNoDataIsPresentNoPropertyIsAdded()
+        var enricher = new ExceptionDataEnricher();
+        var exception = new Exception();
+        var evt = Some.ErrorEvent(exception);
+
+        enricher.Enrich(evt, Some.PropertyFactory());
+
+        Assert.Equal(0, evt.Properties.Count);
+    }
+
+    [Fact]
+    public void WhenDataIsPresentThePropertyIsAdded()
+    {
+        var enricher = new ExceptionDataEnricher();
+        var exception = new Exception()
         {
-            var enricher = new ExceptionDataEnricher();
-            var exception = new Exception();
-            var evt = Some.ErrorEvent(exception);
-
-            enricher.Enrich(evt, Some.PropertyFactory());
-
-            Assert.Equal(0, evt.Properties.Count);
-        }
-
-        [Fact]
-        public void WhenDataIsPresentThePropertyIsAdded()
-        {
-            var enricher = new ExceptionDataEnricher();
-            var exception = new Exception()
+            Data =
             {
-                Data =
-                {
-                    ["A"] = 42,
-                    ["B"] = "Hello"
-                }
-            };
-            var evt = Some.ErrorEvent(exception);
+                ["A"] = 42,
+                ["B"] = "Hello"
+            }
+        };
+        var evt = Some.ErrorEvent(exception);
 
-            enricher.Enrich(evt, Some.PropertyFactory());
+        enricher.Enrich(evt, Some.PropertyFactory());
 
-            Assert.Equal(1, evt.Properties.Count);
-            var data = evt.Properties["ExceptionData"];
-            var value = Assert.IsType<StructureValue>(data);
-            Assert.Equal(2, value.Properties.Count);
-            var a = Assert.IsType<ScalarValue>(value.Properties.Single(p => p.Name == "A").Value);
-            Assert.Equal(42, a.Value);
-            var b = Assert.IsType<ScalarValue>(value.Properties.Single(p => p.Name == "B").Value);
-            Assert.Equal("Hello", b.Value);
-        }
+        Assert.Equal(1, evt.Properties.Count);
+        var data = evt.Properties["ExceptionData"];
+        var value = Assert.IsType<StructureValue>(data);
+        Assert.Equal(2, value.Properties.Count);
+        var a = Assert.IsType<ScalarValue>(value.Properties.Single(p => p.Name == "A").Value);
+        Assert.Equal(42, a.Value);
+        var b = Assert.IsType<ScalarValue>(value.Properties.Single(p => p.Name == "B").Value);
+        Assert.Equal("Hello", b.Value);
     }
 }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -17,10 +17,10 @@ namespace Tests.Serilog.Extensions.Logging
 {
     public class SerilogLoggerTest
     {
-        private const string Name = "test";
-        private const string TestMessage = "This is a test";
+        const string Name = "test";
+        const string TestMessage = "This is a test";
 
-        private Tuple<SerilogLogger, SerilogSink> SetUp(LogLevel logLevel)
+        Tuple<SerilogLogger, SerilogSink> SetUp(LogLevel logLevel)
         {
             var sink = new SerilogSink();
 
@@ -52,12 +52,12 @@ namespace Tests.Serilog.Extensions.Logging
             var logger = t.Item1;
             var sink = t.Item2;
 
-            logger.Log(LogLevel.Trace, 0, TestMessage, null, null);
-            logger.Log(LogLevel.Debug, 0, TestMessage, null, null);
-            logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            logger.Log(LogLevel.Warning, 0, TestMessage, null, null);
-            logger.Log(LogLevel.Error, 0, TestMessage, null, null);
-            logger.Log(LogLevel.Critical, 0, TestMessage, null, null);
+            logger.Log(LogLevel.Trace, 0, TestMessage, null, null!);
+            logger.Log(LogLevel.Debug, 0, TestMessage, null, null!);
+            logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
+            logger.Log(LogLevel.Warning, 0, TestMessage, null, null!);
+            logger.Log(LogLevel.Error, 0, TestMessage, null, null!);
+            logger.Log(LogLevel.Critical, 0, TestMessage, null, null!);
 
             Assert.Equal(6, sink.Writes.Count);
             Assert.Equal(LogLevel.Trace, sink.Writes[0].Level);
@@ -111,7 +111,7 @@ namespace Tests.Serilog.Extensions.Logging
             var logger = t.Item1;
             var sink = t.Item2;
 
-            logger.Log(logLevel, 0, TestMessage, null, null);
+            logger.Log(logLevel, 0, TestMessage, null, null!);
 
             Assert.Equal(expected, sink.Writes.Count);
         }
@@ -354,7 +354,7 @@ namespace Tests.Serilog.Extensions.Logging
             Assert.Equal("Inner", items[1]);
         }
 
-        private class FoodScope : IEnumerable<KeyValuePair<string, object>>
+        class FoodScope : IEnumerable<KeyValuePair<string, object>>
         {
             readonly string _name;
 
@@ -374,7 +374,7 @@ namespace Tests.Serilog.Extensions.Logging
             }
         }
 
-        private class LuckyScope : IEnumerable<KeyValuePair<string, object>>
+        class LuckyScope : IEnumerable<KeyValuePair<string, object>>
         {
             readonly int _luckyNumber;
 
@@ -394,7 +394,7 @@ namespace Tests.Serilog.Extensions.Logging
             }
         }
 
-        private class Person
+        class Person
         {
             public string FirstName { get; set; }
             public string LastName { get; set; }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -6,398 +6,402 @@ using System.Collections;
 using Serilog.Events;
 using Microsoft.Extensions.Logging;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Xunit;
 using Serilog.Extensions.Logging;
 using Seq.Extensions.Logging;
 using Tests.Serilog.Extensions.Logging.Support;
+using Tests.Support;
 
-namespace Tests.Serilog.Extensions.Logging
+namespace Tests.Serilog.Extensions.Logging;
+
+public class SerilogLoggerTests
 {
-    public class SerilogLoggerTest
+    static SerilogLoggerTests()
     {
-        const string Name = "test";
-        const string TestMessage = "This is a test";
+        // This is necessary to force activity id allocation on .NET Framework and early .NET Core versions. When this isn't
+        // done, log events end up carrying null trace and span ids (which is fine).
+        Activity.DefaultIdFormat = ActivityIdFormat.W3C;
+        Activity.ForceDefaultIdFormat = true;
+    }
 
-        Tuple<SerilogLogger, SerilogSink> SetUp(LogLevel logLevel)
+    const string Name = "test";
+    const string TestMessage = "This is a test";
+
+    static (SerilogLogger logger, SerilogSink sink) SetUp(LogLevel logLevel)
+    {
+        var sink = new SerilogSink();
+
+        var l = new global::Serilog.Core.Logger(new global::Serilog.Core.LoggingLevelSwitch(logLevel), sink);
+
+        var provider = new SerilogLoggerProvider(l);
+        provider.SetScopeProvider(new LoggerExternalScopeProvider());
+        var logger = (SerilogLogger)provider.CreateLogger(Name);
+
+        return (logger, sink);
+    }
+
+    [Fact]
+    public void LogsWhenNullFilterGiven()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
+
+        Assert.Single(sink.Writes);
+    }
+
+    [Fact]
+    public void LogsCorrectLevel()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        logger.Log(LogLevel.Trace, 0, TestMessage, null, null!);
+        logger.Log(LogLevel.Debug, 0, TestMessage, null, null!);
+        logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
+        logger.Log(LogLevel.Warning, 0, TestMessage, null, null!);
+        logger.Log(LogLevel.Error, 0, TestMessage, null, null!);
+        logger.Log(LogLevel.Critical, 0, TestMessage, null, null!);
+
+        Assert.Equal(6, sink.Writes.Count);
+        Assert.Equal(LogLevel.Trace, sink.Writes[0].Level);
+        Assert.Equal(LogLevel.Debug, sink.Writes[1].Level);
+        Assert.Equal(LogLevel.Information, sink.Writes[2].Level);
+        Assert.Equal(LogLevel.Warning, sink.Writes[3].Level);
+        Assert.Equal(LogLevel.Error, sink.Writes[4].Level);
+        Assert.Equal(LogLevel.Critical, sink.Writes[5].Level);
+    }
+
+    [Theory]
+    [InlineData(LogLevel.Trace, LogLevel.Trace, 1)]
+    [InlineData(LogLevel.Trace, LogLevel.Debug, 1)]
+    [InlineData(LogLevel.Trace, LogLevel.Information, 1)]
+    [InlineData(LogLevel.Trace, LogLevel.Warning, 1)]
+    [InlineData(LogLevel.Trace, LogLevel.Error, 1)]
+    [InlineData(LogLevel.Trace, LogLevel.Critical, 1)]
+    [InlineData(LogLevel.Debug, LogLevel.Trace, 0)]
+    [InlineData(LogLevel.Debug, LogLevel.Debug, 1)]
+    [InlineData(LogLevel.Debug, LogLevel.Information, 1)]
+    [InlineData(LogLevel.Debug, LogLevel.Warning, 1)]
+    [InlineData(LogLevel.Debug, LogLevel.Error, 1)]
+    [InlineData(LogLevel.Debug, LogLevel.Critical, 1)]
+    [InlineData(LogLevel.Information, LogLevel.Trace, 0)]
+    [InlineData(LogLevel.Information, LogLevel.Debug, 0)]
+    [InlineData(LogLevel.Information, LogLevel.Information, 1)]
+    [InlineData(LogLevel.Information, LogLevel.Warning, 1)]
+    [InlineData(LogLevel.Information, LogLevel.Error, 1)]
+    [InlineData(LogLevel.Information, LogLevel.Critical, 1)]
+    [InlineData(LogLevel.Warning, LogLevel.Trace, 0)]
+    [InlineData(LogLevel.Warning, LogLevel.Debug, 0)]
+    [InlineData(LogLevel.Warning, LogLevel.Information, 0)]
+    [InlineData(LogLevel.Warning, LogLevel.Warning, 1)]
+    [InlineData(LogLevel.Warning, LogLevel.Error, 1)]
+    [InlineData(LogLevel.Warning, LogLevel.Critical, 1)]
+    [InlineData(LogLevel.Error, LogLevel.Trace, 0)]
+    [InlineData(LogLevel.Error, LogLevel.Debug, 0)]
+    [InlineData(LogLevel.Error, LogLevel.Information, 0)]
+    [InlineData(LogLevel.Error, LogLevel.Warning, 0)]
+    [InlineData(LogLevel.Error, LogLevel.Error, 1)]
+    [InlineData(LogLevel.Error, LogLevel.Critical, 1)]
+    [InlineData(LogLevel.Critical, LogLevel.Trace, 0)]
+    [InlineData(LogLevel.Critical, LogLevel.Debug, 0)]
+    [InlineData(LogLevel.Critical, LogLevel.Information, 0)]
+    [InlineData(LogLevel.Critical, LogLevel.Warning, 0)]
+    [InlineData(LogLevel.Critical, LogLevel.Error, 0)]
+    [InlineData(LogLevel.Critical, LogLevel.Critical, 1)]
+    public void LogsWhenEnabled(LogLevel minLevel, LogLevel logLevel, int expected)
+    {
+        var (logger, sink) = SetUp(minLevel);
+
+        logger.Log(logLevel, 0, TestMessage, null, null!);
+
+        Assert.Equal(expected, sink.Writes.Count);
+    }
+
+    [Fact]
+    public void LogsCorrectMessage()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        logger.Log<object>(LogLevel.Information, 0, null, null, null!);
+        logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
+        logger.Log<object>(LogLevel.Information, 0, null, null, (_, _) => TestMessage);
+
+        Assert.Equal(3, sink.Writes.Count);
+
+        Assert.Equal(1, sink.Writes[0].Properties.Count);
+        Assert.Empty(sink.Writes[0].RenderMessage());
+
+        Assert.Equal(2, sink.Writes[1].Properties.Count);
+        Assert.True(sink.Writes[1].Properties.ContainsKey("State"));
+        Assert.Equal(TestMessage, sink.Writes[1].RenderMessage());
+
+        Assert.Equal(2, sink.Writes[2].Properties.Count);
+        Assert.True(sink.Writes[2].Properties.ContainsKey("Message"));
+        Assert.Equal(TestMessage, sink.Writes[2].RenderMessage());
+    }
+
+    [Fact]
+    public void CarriesException()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        var exception = new Exception();
+
+        logger.Log(LogLevel.Information, 0, "Test", exception, null!);
+
+        Assert.Single(sink.Writes);
+        Assert.Same(exception, sink.Writes[0].Exception);
+    }
+
+    [Fact]
+    public void SingleScopeProperty()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope(new FoodScope("pizza")))
         {
-            var sink = new SerilogSink();
-
-            var l = new global::Serilog.Core.Logger(new global::Serilog.Core.LoggingLevelSwitch(logLevel), sink);
-
-            var provider = new SerilogLoggerProvider(l);
-            provider.SetScopeProvider(new LoggerExternalScopeProvider());
-            var logger = (SerilogLogger)provider.CreateLogger(Name);
-
-            return new Tuple<SerilogLogger, SerilogSink>(logger, sink);
-        }
-
-        [Fact]
-        public void LogsWhenNullFilterGiven()
-        {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
             logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
-
-            Assert.Single(sink.Writes);
         }
 
-        [Fact]
-        public void LogsCorrectLevel()
-        {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
+        Assert.Single(sink.Writes);
+        Assert.True(sink.Writes[0].Properties.ContainsKey("Name"));
+        Assert.Equal("\"pizza\"", sink.Writes[0].Properties["Name"].ToString());
+    }
 
-            logger.Log(LogLevel.Trace, 0, TestMessage, null, null!);
-            logger.Log(LogLevel.Debug, 0, TestMessage, null, null!);
+    [Fact]
+    public void NestedScopeSameProperty()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope(new FoodScope("avocado")))
+        {
+            using (logger.BeginScope(new FoodScope("bacon")))
+            {
+                logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
+            }
+        }
+
+        // Should retain the property of the most specific scope
+        Assert.Single(sink.Writes);
+        Assert.True(sink.Writes[0].Properties.ContainsKey("Name"));
+        Assert.Equal("\"bacon\"", sink.Writes[0].Properties["Name"].ToString());
+    }
+
+    [Fact]
+    public void NestedScopesDifferentProperties()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope(new FoodScope("spaghetti")))
+        {
+            using (logger.BeginScope(new LuckyScope(7)))
+            {
+                logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
+            }
+        }
+
+        Assert.Single(sink.Writes);
+        Assert.True(sink.Writes[0].Properties.ContainsKey("Name"));
+        Assert.Equal("\"spaghetti\"", sink.Writes[0].Properties["Name"].ToString());
+        Assert.True(sink.Writes[0].Properties.ContainsKey("LuckyNumber"));
+        Assert.Equal("7", sink.Writes[0].Properties["LuckyNumber"].ToString());
+    }
+
+    [Fact]
+    public void CarriesMessageTemplateProperties()
+    {
+        var selfLog = new StringWriter();
+        SelfLog.Enable(selfLog);
+
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        logger.LogInformation("Hello, {Recipient}", "World");
+
+        Assert.True(sink.Writes[0].Properties.ContainsKey("Recipient"));
+        Assert.Equal("\"World\"", sink.Writes[0].Properties["Recipient"].ToString());
+        Assert.Equal("Hello, {Recipient}", sink.Writes[0].MessageTemplate.Text);
+
+        SelfLog.Disable();
+        Assert.Empty(selfLog.ToString());
+    }
+
+    [Fact]
+    public void CarriesEventIdIfNonzero()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        const int expected = 42;
+
+        logger.Log(LogLevel.Information, expected, "Test", null, null!);
+
+        Assert.Single(sink.Writes);
+
+        var eventId = (StructureValue)sink.Writes[0].Properties["EventId"];
+        var id = (ScalarValue)eventId.Properties.Single(p => p.Name == "Id").Value;
+        Assert.Equal(42, id.Value);
+    }
+
+    [Fact]
+    public void BeginScopeDestructuresObjectsWhenDestructurerIsUsedInMessageTemplate()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope("{@Person}", new Person { FirstName = "John", LastName = "Smith" }))
+        {
             logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
-            logger.Log(LogLevel.Warning, 0, TestMessage, null, null!);
-            logger.Log(LogLevel.Error, 0, TestMessage, null, null!);
-            logger.Log(LogLevel.Critical, 0, TestMessage, null, null!);
-
-            Assert.Equal(6, sink.Writes.Count);
-            Assert.Equal(LogLevel.Trace, sink.Writes[0].Level);
-            Assert.Equal(LogLevel.Debug, sink.Writes[1].Level);
-            Assert.Equal(LogLevel.Information, sink.Writes[2].Level);
-            Assert.Equal(LogLevel.Warning, sink.Writes[3].Level);
-            Assert.Equal(LogLevel.Error, sink.Writes[4].Level);
-            Assert.Equal(LogLevel.Critical, sink.Writes[5].Level);
         }
 
-        [Theory]
-        [InlineData(LogLevel.Trace, LogLevel.Trace, 1)]
-        [InlineData(LogLevel.Trace, LogLevel.Debug, 1)]
-        [InlineData(LogLevel.Trace, LogLevel.Information, 1)]
-        [InlineData(LogLevel.Trace, LogLevel.Warning, 1)]
-        [InlineData(LogLevel.Trace, LogLevel.Error, 1)]
-        [InlineData(LogLevel.Trace, LogLevel.Critical, 1)]
-        [InlineData(LogLevel.Debug, LogLevel.Trace, 0)]
-        [InlineData(LogLevel.Debug, LogLevel.Debug, 1)]
-        [InlineData(LogLevel.Debug, LogLevel.Information, 1)]
-        [InlineData(LogLevel.Debug, LogLevel.Warning, 1)]
-        [InlineData(LogLevel.Debug, LogLevel.Error, 1)]
-        [InlineData(LogLevel.Debug, LogLevel.Critical, 1)]
-        [InlineData(LogLevel.Information, LogLevel.Trace, 0)]
-        [InlineData(LogLevel.Information, LogLevel.Debug, 0)]
-        [InlineData(LogLevel.Information, LogLevel.Information, 1)]
-        [InlineData(LogLevel.Information, LogLevel.Warning, 1)]
-        [InlineData(LogLevel.Information, LogLevel.Error, 1)]
-        [InlineData(LogLevel.Information, LogLevel.Critical, 1)]
-        [InlineData(LogLevel.Warning, LogLevel.Trace, 0)]
-        [InlineData(LogLevel.Warning, LogLevel.Debug, 0)]
-        [InlineData(LogLevel.Warning, LogLevel.Information, 0)]
-        [InlineData(LogLevel.Warning, LogLevel.Warning, 1)]
-        [InlineData(LogLevel.Warning, LogLevel.Error, 1)]
-        [InlineData(LogLevel.Warning, LogLevel.Critical, 1)]
-        [InlineData(LogLevel.Error, LogLevel.Trace, 0)]
-        [InlineData(LogLevel.Error, LogLevel.Debug, 0)]
-        [InlineData(LogLevel.Error, LogLevel.Information, 0)]
-        [InlineData(LogLevel.Error, LogLevel.Warning, 0)]
-        [InlineData(LogLevel.Error, LogLevel.Error, 1)]
-        [InlineData(LogLevel.Error, LogLevel.Critical, 1)]
-        [InlineData(LogLevel.Critical, LogLevel.Trace, 0)]
-        [InlineData(LogLevel.Critical, LogLevel.Debug, 0)]
-        [InlineData(LogLevel.Critical, LogLevel.Information, 0)]
-        [InlineData(LogLevel.Critical, LogLevel.Warning, 0)]
-        [InlineData(LogLevel.Critical, LogLevel.Error, 0)]
-        [InlineData(LogLevel.Critical, LogLevel.Critical, 1)]
-        public void LogsWhenEnabled(LogLevel minLevel, LogLevel logLevel, int expected)
+        Assert.Single(sink.Writes);
+        Assert.True(sink.Writes[0].Properties.ContainsKey("Person"));
+
+        var person = (StructureValue)sink.Writes[0].Properties["Person"];
+        var firstName = (ScalarValue)person.Properties.Single(p => p.Name == "FirstName").Value;
+        var lastName = (ScalarValue)person.Properties.Single(p => p.Name == "LastName").Value;
+        Assert.Equal("John", firstName.Value);
+        Assert.Equal("Smith", lastName.Value);
+    }
+
+    [Fact]
+    public void BeginScopeDestructuresObjectsWhenDestructurerIsUsedInDictionary()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope(new Dictionary<string, object> { { "@Person", new Person { FirstName = "John", LastName = "Smith" } } }))
         {
-            var t = SetUp(minLevel);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            logger.Log(logLevel, 0, TestMessage, null, null!);
-
-            Assert.Equal(expected, sink.Writes.Count);
+            logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
         }
 
-        [Fact]
-        public void LogsCorrectMessage()
+        Assert.Single(sink.Writes);
+        Assert.True(sink.Writes[0].Properties.ContainsKey("Person"));
+
+        var person = (StructureValue)sink.Writes[0].Properties["Person"];
+        var firstName = (ScalarValue)person.Properties.Single(p => p.Name == "FirstName").Value;
+        var lastName = (ScalarValue)person.Properties.Single(p => p.Name == "LastName").Value;
+        Assert.Equal("John", firstName.Value);
+        Assert.Equal("Smith", lastName.Value);
+    }
+
+    [Fact]
+    public void BeginScopeDoesNotModifyKeyWhenDestructurerIsNotUsedInMessageTemplate()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope("{FirstName}", "John"))
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            logger.Log<object>(LogLevel.Information, 0, null, null, null);
-            logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            logger.Log<object>(LogLevel.Information, 0, null, null, (_, __) => TestMessage);
-
-            Assert.Equal(3, sink.Writes.Count);
-
-            Assert.Equal(1, sink.Writes[0].Properties.Count);
-            Assert.Empty(sink.Writes[0].RenderMessage());
-
-            Assert.Equal(2, sink.Writes[1].Properties.Count);
-            Assert.True(sink.Writes[1].Properties.ContainsKey("State"));
-            Assert.Equal(TestMessage, sink.Writes[1].RenderMessage());
-
-            Assert.Equal(2, sink.Writes[2].Properties.Count);
-            Assert.True(sink.Writes[2].Properties.ContainsKey("Message"));
-            Assert.Equal(TestMessage, sink.Writes[2].RenderMessage());
+            logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
         }
 
-        [Fact]
-        public void CarriesException()
+        Assert.Single(sink.Writes);
+        Assert.True(sink.Writes[0].Properties.ContainsKey("FirstName"));
+    }
+
+    [Fact]
+    public void BeginScopeDoesNotModifyKeyWhenDestructurerIsNotUsedInDictionary()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope(new Dictionary<string, object> { { "FirstName", "John" } }))
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            var exception = new Exception();
-
-            logger.Log(LogLevel.Information, 0, "Test", exception, null);
-
-            Assert.Single(sink.Writes);
-            Assert.Same(exception, sink.Writes[0].Exception);
+            logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
         }
 
-        [Fact]
-        public void SingleScopeProperty()
+        Assert.Single(sink.Writes);
+        Assert.True(sink.Writes[0].Properties.ContainsKey("FirstName"));
+    }
+
+    [Fact]
+    public void NamedScopesAreCaptured()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        using (logger.BeginScope("Outer"))
+        using (logger.BeginScope("Inner"))
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope(new FoodScope("pizza")))
-            {
-                logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            }
-
-            Assert.Single(sink.Writes);
-            Assert.True(sink.Writes[0].Properties.ContainsKey("Name"));
-            Assert.Equal("\"pizza\"", sink.Writes[0].Properties["Name"].ToString());
+            logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
         }
 
-        [Fact]
-        public void NestedScopeSameProperty()
+        Assert.Single(sink.Writes);
+
+        Assert.True(sink.Writes[0].Properties.TryGetValue(SerilogLoggerProvider.ScopePropertyName, out var scopeValue));
+
+        var items = (scopeValue as SequenceValue)?.Elements.Select(e => ((ScalarValue)e).Value).Cast<string>().ToArray();
+        Assert.Equal(2, items!.Length);
+        Assert.Equal("Outer", items[0]);
+        Assert.Equal("Inner", items[1]);
+    }
+
+    [Fact]
+    public void CurrentActivityIsCapturedAtLogEventCreation()
+    {
+        using var listener = new ActivityListener();
+        listener.ShouldListenTo = _ => true;
+        listener.SampleUsingParentId = (ref ActivityCreationOptions<string> _) => ActivitySamplingResult.AllData;
+        listener.Sample = (ref ActivityCreationOptions<ActivityContext> _) => ActivitySamplingResult.AllData;
+        ActivitySource.AddActivityListener(listener);
+
+        using var source = new ActivitySource(Some.String());
+        using var activity = source.StartActivity(Some.String());
+        Assert.NotNull(activity);
+        Assert.NotEqual(default(ActivityTraceId).ToHexString(), activity.TraceId.ToHexString());
+        Assert.NotEqual(default(ActivitySpanId).ToHexString(), activity.SpanId.ToHexString());
+
+        var (logger, sink) = SetUp(LogLevel.Trace);
+        logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
+
+        var single = sink.SingleWrite;
+
+        Assert.Equal(activity.TraceId, single.TraceId);
+        Assert.Equal(activity.SpanId, single.SpanId);
+    }
+
+    class FoodScope : IEnumerable<KeyValuePair<string, object>>
+    {
+        readonly string _name;
+
+        public FoodScope(string name)
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope(new FoodScope("avocado")))
-            {
-                using (logger.BeginScope(new FoodScope("bacon")))
-                {
-                    logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-                }
-            }
-
-            // Should retain the property of the most specific scope
-            Assert.Single(sink.Writes);
-            Assert.True(sink.Writes[0].Properties.ContainsKey("Name"));
-            Assert.Equal("\"bacon\"", sink.Writes[0].Properties["Name"].ToString());
+            _name = name;
         }
 
-        [Fact]
-        public void NestedScopesDifferentProperties()
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope(new FoodScope("spaghetti")))
-            {
-                using (logger.BeginScope(new LuckyScope(7)))
-                {
-                    logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-                }
-            }
-
-            Assert.Single(sink.Writes);
-            Assert.True(sink.Writes[0].Properties.ContainsKey("Name"));
-            Assert.Equal("\"spaghetti\"", sink.Writes[0].Properties["Name"].ToString());
-            Assert.True(sink.Writes[0].Properties.ContainsKey("LuckyNumber"));
-            Assert.Equal("7", sink.Writes[0].Properties["LuckyNumber"].ToString());
+            yield return new KeyValuePair<string, object>("Name", _name);
         }
 
-        [Fact]
-        public void CarriesMessageTemplateProperties()
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            var selfLog = new StringWriter();
-            SelfLog.Enable(selfLog);
-
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            logger.LogInformation("Hello, {Recipient}", "World");
-
-            Assert.True(sink.Writes[0].Properties.ContainsKey("Recipient"));
-            Assert.Equal("\"World\"", sink.Writes[0].Properties["Recipient"].ToString());
-            Assert.Equal("Hello, {Recipient}", sink.Writes[0].MessageTemplate.Text);
-
-            SelfLog.Disable();
-            Assert.Empty(selfLog.ToString());
+            return GetEnumerator();
         }
+    }
 
-        [Fact]
-        public void CarriesEventIdIfNonzero()
+    class LuckyScope : IEnumerable<KeyValuePair<string, object>>
+    {
+        readonly int _luckyNumber;
+
+        public LuckyScope(int luckyNumber)
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            int expected = 42;
-
-            logger.Log(LogLevel.Information, expected, "Test", null, null);
-
-            Assert.Single(sink.Writes);
-
-            var eventId = (StructureValue)sink.Writes[0].Properties["EventId"];
-            var id = (ScalarValue)eventId.Properties.Single(p => p.Name == "Id").Value;
-            Assert.Equal(42, id.Value);
+            _luckyNumber = luckyNumber;
         }
 
-        [Fact]
-        public void BeginScopeDestructuresObjectsWhenDestructurerIsUsedInMessageTemplate()
+        public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope("{@Person}", new Person { FirstName = "John", LastName = "Smith" }))
-            {
-                logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            }
-
-            Assert.Single(sink.Writes);
-            Assert.True(sink.Writes[0].Properties.ContainsKey("Person"));
-
-            var person = (StructureValue)sink.Writes[0].Properties["Person"];
-            var firstName = (ScalarValue)person.Properties.Single(p => p.Name == "FirstName").Value;
-            var lastName = (ScalarValue)person.Properties.Single(p => p.Name == "LastName").Value;
-            Assert.Equal("John", firstName.Value);
-            Assert.Equal("Smith", lastName.Value);
+            yield return new KeyValuePair<string, object>("LuckyNumber", _luckyNumber);
         }
 
-        [Fact]
-        public void BeginScopeDestructuresObjectsWhenDestructurerIsUsedInDictionary()
+        IEnumerator IEnumerable.GetEnumerator()
         {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope(new Dictionary<string, object> { { "@Person", new Person { FirstName = "John", LastName = "Smith" } } }))
-            {
-                logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            }
-
-            Assert.Single(sink.Writes);
-            Assert.True(sink.Writes[0].Properties.ContainsKey("Person"));
-
-            var person = (StructureValue)sink.Writes[0].Properties["Person"];
-            var firstName = (ScalarValue)person.Properties.Single(p => p.Name == "FirstName").Value;
-            var lastName = (ScalarValue)person.Properties.Single(p => p.Name == "LastName").Value;
-            Assert.Equal("John", firstName.Value);
-            Assert.Equal("Smith", lastName.Value);
+            return GetEnumerator();
         }
+    }
 
-        [Fact]
-        public void BeginScopeDoesNotModifyKeyWhenDestructurerIsNotUsedInMessageTemplate()
-        {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope("{FirstName}", "John"))
-            {
-                logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            }
-
-            Assert.Single(sink.Writes);
-            Assert.True(sink.Writes[0].Properties.ContainsKey("FirstName"));
-        }
-
-        [Fact]
-        public void BeginScopeDoesNotModifyKeyWhenDestructurerIsNotUsedInDictionary()
-        {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope(new Dictionary<string, object> { { "FirstName", "John" } }))
-            {
-                logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            }
-
-            Assert.Single(sink.Writes);
-            Assert.True(sink.Writes[0].Properties.ContainsKey("FirstName"));
-        }
-
-        [Fact]
-        public void NamedScopesAreCaptured()
-        {
-            var t = SetUp(LogLevel.Trace);
-            var logger = t.Item1;
-            var sink = t.Item2;
-
-            using (logger.BeginScope("Outer"))
-            using (logger.BeginScope("Inner"))
-            {
-                logger.Log(LogLevel.Information, 0, TestMessage, null, null);
-            }
-
-            Assert.Single(sink.Writes);
-
-            LogEventPropertyValue scopeValue;
-            Assert.True(sink.Writes[0].Properties.TryGetValue(SerilogLoggerProvider.ScopePropertyName, out scopeValue));
-
-            var items = (scopeValue as SequenceValue)?.Elements.Select(e => ((ScalarValue)e).Value).Cast<string>().ToArray();
-            Assert.Equal(2, items.Length);
-            Assert.Equal("Outer", items[0]);
-            Assert.Equal("Inner", items[1]);
-        }
-
-        class FoodScope : IEnumerable<KeyValuePair<string, object>>
-        {
-            readonly string _name;
-
-            public FoodScope(string name)
-            {
-                _name = name;
-            }
-
-            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-            {
-                yield return new KeyValuePair<string, object>("Name", _name);
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-        }
-
-        class LuckyScope : IEnumerable<KeyValuePair<string, object>>
-        {
-            readonly int _luckyNumber;
-
-            public LuckyScope(int luckyNumber)
-            {
-                _luckyNumber = luckyNumber;
-            }
-
-            public IEnumerator<KeyValuePair<string, object>> GetEnumerator()
-            {
-                yield return new KeyValuePair<string, object>("LuckyNumber", _luckyNumber);
-            }
-
-            IEnumerator IEnumerable.GetEnumerator()
-            {
-                return GetEnumerator();
-            }
-        }
-
-        class Person
-        {
-            public string FirstName { get; set; }
-            public string LastName { get; set; }
-        }
+    class Person
+    {
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public string FirstName { get; set; }
+        // ReSharper disable once UnusedAutoPropertyAccessor.Local
+        public string LastName { get; set; }
     }
 }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -40,7 +40,7 @@ namespace Tests.Serilog.Extensions.Logging
             var logger = t.Item1;
             var sink = t.Item2;
 
-            logger.Log(LogLevel.Information, 0, TestMessage, null, null);
+            logger.Log(LogLevel.Information, 0, TestMessage, null, null!);
 
             Assert.Single(sink.Writes);
         }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/Support/SerilogSink.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/Support/SerilogSink.cs
@@ -4,16 +4,17 @@
 using System.Collections.Generic;
 using Serilog.Core;
 using Serilog.Events;
+using Xunit;
 
-namespace Tests.Serilog.Extensions.Logging.Support
+namespace Tests.Serilog.Extensions.Logging.Support;
+
+class SerilogSink : ILogEventSink
 {
-    class SerilogSink : ILogEventSink
-    {
-        public List<LogEvent> Writes { get; set; } = new List<LogEvent>();
+    public List<LogEvent> Writes { get; } = [];
+    public LogEvent SingleWrite => Assert.Single(Writes);
 
-        public void Emit(LogEvent logEvent)
-        {
-            Writes.Add(logEvent);
-        }
+    public void Emit(LogEvent logEvent)
+    {
+        Writes.Add(logEvent);
     }
 }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/BatchedConnectionStatusTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/BatchedConnectionStatusTests.cs
@@ -17,114 +17,113 @@ using System.Globalization;
 using Xunit;
 using Serilog.Sinks.PeriodicBatching;
 
-namespace Seq.Extensions.Logging.Tests.Serilog.Sinks
+namespace Seq.Extensions.Logging.Tests.Serilog.Sinks;
+
+public class BatchedConnectionStatusTests
 {
-    public class BatchedConnectionStatusTests
+    readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
+
+    [Fact]
+    public void WhenNoFailuresHaveOccurredTheRegularIntervalIsUsed()
     {
-        readonly TimeSpan DefaultPeriod = TimeSpan.FromSeconds(2);
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        Assert.Equal(DefaultPeriod, bcs.NextInterval);
+    }
 
-        [Fact]
-        public void WhenNoFailuresHaveOccurredTheRegularIntervalIsUsed()
-        {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            Assert.Equal(DefaultPeriod, bcs.NextInterval);
-        }
+    [Fact]
+    public void WhenOneFailureHasOccurredTheRegularIntervalIsUsed()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        bcs.MarkFailure();
+        Assert.Equal(DefaultPeriod, bcs.NextInterval);
+    }
 
-        [Fact]
-        public void WhenOneFailureHasOccurredTheRegularIntervalIsUsed()
-        {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            bcs.MarkFailure();
-            Assert.Equal(DefaultPeriod, bcs.NextInterval);
-        }
+    [Fact]
+    public void WhenTwoFailuresHaveOccurredTheIntervalBacksOff()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        bcs.MarkFailure();
+        bcs.MarkFailure();
+        Assert.Equal(TimeSpan.FromSeconds(10), bcs.NextInterval);
+    }
 
-        [Fact]
-        public void WhenTwoFailuresHaveOccurredTheIntervalBacksOff()
-        {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            bcs.MarkFailure();
-            bcs.MarkFailure();
-            Assert.Equal(TimeSpan.FromSeconds(10), bcs.NextInterval);
-        }
+    [Fact]
+    public void WhenABatchSucceedsTheStatusResets()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        bcs.MarkFailure();
+        bcs.MarkFailure();
+        bcs.MarkSuccess();
+        Assert.Equal(DefaultPeriod, bcs.NextInterval);
+    }
 
-        [Fact]
-        public void WhenABatchSucceedsTheStatusResets()
-        {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            bcs.MarkFailure();
-            bcs.MarkFailure();
-            bcs.MarkSuccess();
-            Assert.Equal(DefaultPeriod, bcs.NextInterval);
-        }
+    [Fact]
+    public void WhenThreeFailuresHaveOccurredTheIntervalBacksOff()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        bcs.MarkFailure();
+        bcs.MarkFailure();
+        bcs.MarkFailure();
+        Assert.Equal(TimeSpan.FromSeconds(20), bcs.NextInterval);
+        Assert.False(bcs.ShouldDropBatch);
+    }
 
-        [Fact]
-        public void WhenThreeFailuresHaveOccurredTheIntervalBacksOff()
+    [Fact]
+    public void When8FailuresHaveOccurredTheIntervalBacksOffAndBatchIsDropped()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        for (var i = 0; i < 8; ++i)
         {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            bcs.MarkFailure();
-            bcs.MarkFailure();
-            bcs.MarkFailure();
-            Assert.Equal(TimeSpan.FromSeconds(20), bcs.NextInterval);
             Assert.False(bcs.ShouldDropBatch);
+            bcs.MarkFailure();
         }
+        Assert.Equal(TimeSpan.FromMinutes(10), bcs.NextInterval);
+        Assert.True(bcs.ShouldDropBatch);
+        Assert.False(bcs.ShouldDropQueue);
+    }
 
-        [Fact]
-        public void When8FailuresHaveOccurredTheIntervalBacksOffAndBatchIsDropped()
+    [Fact]
+    public void When10FailuresHaveOccurredTheQueueIsDropped()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        for (var i = 0; i < 10; ++i)
         {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            for (var i = 0; i < 8; ++i)
-            {
-                Assert.False(bcs.ShouldDropBatch);
-                bcs.MarkFailure();
-            }
-            Assert.Equal(TimeSpan.FromMinutes(10), bcs.NextInterval);
-            Assert.True(bcs.ShouldDropBatch);
             Assert.False(bcs.ShouldDropQueue);
+            bcs.MarkFailure();
         }
+        Assert.True(bcs.ShouldDropQueue);
+    }
 
-        [Fact]
-        public void When10FailuresHaveOccurredTheQueueIsDropped()
+    [Fact]
+    public void AtTheDefaultIntervalRetriesFor10MinutesBeforeDroppingBatch()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        var cumulative = TimeSpan.Zero;
+        do
         {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            for (var i = 0; i < 10; ++i)
-            {
-                Assert.False(bcs.ShouldDropQueue);
-                bcs.MarkFailure();
-            }
-            Assert.True(bcs.ShouldDropQueue);
-        }
+            bcs.MarkFailure();
 
-        [Fact]
-        public void AtTheDefaultIntervalRetriesFor10MinutesBeforeDroppingBatch()
+            if (!bcs.ShouldDropBatch)
+                cumulative += bcs.NextInterval;
+        } while (!bcs.ShouldDropBatch);
+
+        Assert.False(bcs.ShouldDropQueue);
+        Assert.Equal(TimeSpan.Parse("00:10:32", CultureInfo.InvariantCulture), cumulative);
+    }
+
+    [Fact]
+    public void AtTheDefaultIntervalRetriesFor30MinutesBeforeDroppingQueue()
+    {
+        var bcs = new BatchedConnectionStatus(DefaultPeriod);
+        var cumulative = TimeSpan.Zero;
+        do
         {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            var cumulative = TimeSpan.Zero;
-            do
-            {
-                bcs.MarkFailure();
+            bcs.MarkFailure();
 
-                if (!bcs.ShouldDropBatch)
-                    cumulative += bcs.NextInterval;
-            } while (!bcs.ShouldDropBatch);
+            if (!bcs.ShouldDropQueue)
+                cumulative += bcs.NextInterval;
+        } while (!bcs.ShouldDropQueue);
 
-            Assert.False(bcs.ShouldDropQueue);
-            Assert.Equal(TimeSpan.Parse("00:10:32", CultureInfo.InvariantCulture), cumulative);
-        }
-
-        [Fact]
-        public void AtTheDefaultIntervalRetriesFor30MinutesBeforeDroppingQueue()
-        {
-            var bcs = new BatchedConnectionStatus(DefaultPeriod);
-            var cumulative = TimeSpan.Zero;
-            do
-            {
-                bcs.MarkFailure();
-
-                if (!bcs.ShouldDropQueue)
-                    cumulative += bcs.NextInterval;
-            } while (!bcs.ShouldDropQueue);
-
-            Assert.Equal(TimeSpan.Parse("00:30:32", CultureInfo.InvariantCulture), cumulative);
-        }
+        Assert.Equal(TimeSpan.Parse("00:30:32", CultureInfo.InvariantCulture), cumulative);
     }
 }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/ControlledLevelSwitchTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/ControlledLevelSwitchTests.cs
@@ -4,88 +4,87 @@ using Serilog.Sinks.Seq;
 using Tests.Support;
 using Xunit;
 
-namespace Tests.Serilog.Sinks.Seq
+namespace Tests.Serilog.Sinks.Seq;
+
+public class ControlledLevelSwitchTests
 {
-    public class ControlledLevelSwitchTests
+    [Fact]
+    public void WhenTheServerSendsALevelTheSwitchIsAdjusted()
     {
-        [Fact]
-        public void WhenTheServerSendsALevelTheSwitchIsAdjusted()
-        {
-            var lls = new LoggingLevelSwitch(LogLevel.Warning);
-            var cls = new ControlledLevelSwitch(lls);
-            cls.Update(LogLevel.Debug);
-            Assert.Equal(LogLevel.Debug, lls.MinimumLevel);
-        }
+        var lls = new LoggingLevelSwitch(LogLevel.Warning);
+        var cls = new ControlledLevelSwitch(lls);
+        cls.Update(LogLevel.Debug);
+        Assert.Equal(LogLevel.Debug, lls.MinimumLevel);
+    }
 
-        [Fact]
-        public void WhenTheServerSendsNoLevelTheSwitchIsNotInitiallyAdjusted()
-        {
-            var lls = new LoggingLevelSwitch(LogLevel.Warning);
-            lls.MinimumLevel = LogLevel.Critical;
-            var cls = new ControlledLevelSwitch(lls);
-            cls.Update(null);
-            Assert.Equal(LogLevel.Critical, lls.MinimumLevel);
-        }
+    [Fact]
+    public void WhenTheServerSendsNoLevelTheSwitchIsNotInitiallyAdjusted()
+    {
+        var lls = new LoggingLevelSwitch(LogLevel.Warning);
+        lls.MinimumLevel = LogLevel.Critical;
+        var cls = new ControlledLevelSwitch(lls);
+        cls.Update(null);
+        Assert.Equal(LogLevel.Critical, lls.MinimumLevel);
+    }
 
-        [Fact]
-        public void WhenTheServerSendsNoLevelTheSwitchIsResetIfPreviouslyAdjusted()
-        {
-            var lls = new LoggingLevelSwitch(LogLevel.Warning);
-            var cls = new ControlledLevelSwitch(lls);
-            cls.Update(LogLevel.Information);
-            cls.Update(null);
-            Assert.Equal(LogLevel.Warning, lls.MinimumLevel);
-        }
+    [Fact]
+    public void WhenTheServerSendsNoLevelTheSwitchIsResetIfPreviouslyAdjusted()
+    {
+        var lls = new LoggingLevelSwitch(LogLevel.Warning);
+        var cls = new ControlledLevelSwitch(lls);
+        cls.Update(LogLevel.Information);
+        cls.Update(null);
+        Assert.Equal(LogLevel.Warning, lls.MinimumLevel);
+    }
 
-        [Fact]
-        public void WithNoSwitchToControlAllEventsAreIncluded()
-        {
-            var cls = new ControlledLevelSwitch(null);
-            Assert.True(cls.IsIncluded(Some.DebugEvent()));
-        }
+    [Fact]
+    public void WithNoSwitchToControlAllEventsAreIncluded()
+    {
+        var cls = new ControlledLevelSwitch(null);
+        Assert.True(cls.IsIncluded(Some.DebugEvent()));
+    }
 
-        [Fact]
-        public void WithNoSwitchToControlEventsAreStillFiltered()
-        {
-            var cls = new ControlledLevelSwitch(null);
-            cls.Update(LogLevel.Warning);
-            Assert.True(cls.IsIncluded(Some.ErrorEvent()));
-            Assert.False(cls.IsIncluded(Some.InformationEvent()));
-        }
+    [Fact]
+    public void WithNoSwitchToControlEventsAreStillFiltered()
+    {
+        var cls = new ControlledLevelSwitch(null);
+        cls.Update(LogLevel.Warning);
+        Assert.True(cls.IsIncluded(Some.ErrorEvent()));
+        Assert.False(cls.IsIncluded(Some.InformationEvent()));
+    }
 
-        [Fact]
-        public void WithNoSwitchToControlAllEventsAreIncludedAfterReset()
-        {
-            var cls = new ControlledLevelSwitch(null);
-            cls.Update(LogLevel.Warning);
-            cls.Update(null);
-            Assert.True(cls.IsIncluded(Some.DebugEvent()));
-        }
+    [Fact]
+    public void WithNoSwitchToControlAllEventsAreIncludedAfterReset()
+    {
+        var cls = new ControlledLevelSwitch(null);
+        cls.Update(LogLevel.Warning);
+        cls.Update(null);
+        Assert.True(cls.IsIncluded(Some.DebugEvent()));
+    }
 
-        [Fact]
-        public void WhenControllingASwitchTheControllerIsActive()
-        {
-            var cls = new ControlledLevelSwitch(new LoggingLevelSwitch());
-            Assert.True(cls.IsActive);
-        }
+    [Fact]
+    public void WhenControllingASwitchTheControllerIsActive()
+    {
+        var cls = new ControlledLevelSwitch(new LoggingLevelSwitch());
+        Assert.True(cls.IsActive);
+    }
 
-        [Fact]
-        public void WhenNotControllingASwitchTheControllerIsNotActive()
-        {
-            var cls = new ControlledLevelSwitch();
-            Assert.False(cls.IsActive);
-        }
+    [Fact]
+    public void WhenNotControllingASwitchTheControllerIsNotActive()
+    {
+        var cls = new ControlledLevelSwitch();
+        Assert.False(cls.IsActive);
+    }
 
-        [Fact]
-        public void AfterServerControlhTheControllerIsAlwaysActive()
-        {
-            var cls = new ControlledLevelSwitch();
+    [Fact]
+    public void AfterServerControlhTheControllerIsAlwaysActive()
+    {
+        var cls = new ControlledLevelSwitch();
 
-            cls.Update(LogLevel.Information);
-            Assert.True(cls.IsActive);
+        cls.Update(LogLevel.Information);
+        Assert.True(cls.IsActive);
 
-            cls.Update(null);
-            Assert.True(cls.IsActive);
-        }
+        cls.Update(null);
+        Assert.True(cls.IsActive);
     }
 }

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/SeqPayloadFormatterTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Sinks/Seq/SeqPayloadFormatterTests.cs
@@ -2,25 +2,24 @@
 using Tests.Support;
 using Xunit;
 
-namespace Seq.Extensions.Logging.Tests.Serilog.Sinks.Seq
-{
-    public class SeqPayloadFormatterTests
-    {
-        [Fact]
-        public void JsonSafeStringPropertiesAreIncludedAsIs()
-        {
-            const string json = "{\"A\": 42}";
-            var evt = Some.LogEvent("The answer is {Answer}", new JsonSafeString(json));
-            var payload = SeqPayloadFormatter.FormatCompactPayload(new[] { evt }, null);
-            Assert.Contains("\"Answer\":{\"A\": 42}", payload);
-        }
+namespace Seq.Extensions.Logging.Tests.Serilog.Sinks.Seq;
 
-        [Fact]
-        public void DefaultJsonSafeStringsDoNotCorruptPayload()
-        {
-            var evt = Some.LogEvent("The answer is {Answer}", (JsonSafeString)default);
-            var payload = SeqPayloadFormatter.FormatCompactPayload(new[] { evt }, null);
-            Assert.Contains("\"Answer\":\"<null>\"", payload);
-        }
+public class SeqPayloadFormatterTests
+{
+    [Fact]
+    public void JsonSafeStringPropertiesAreIncludedAsIs()
+    {
+        const string json = "{\"A\": 42}";
+        var evt = Some.LogEvent("The answer is {Answer}", new JsonSafeString(json));
+        var payload = SeqPayloadFormatter.FormatCompactPayload(new[] { evt }, null);
+        Assert.Contains("\"Answer\":{\"A\": 42}", payload);
+    }
+
+    [Fact]
+    public void DefaultJsonSafeStringsDoNotCorruptPayload()
+    {
+        var evt = Some.LogEvent("The answer is {Answer}", (JsonSafeString)default);
+        var payload = SeqPayloadFormatter.FormatCompactPayload(new[] { evt }, null);
+        Assert.Contains("\"Answer\":\"<null>\"", payload);
     }
 }

--- a/test/Seq.Extensions.Logging.Tests/Support/Some.cs
+++ b/test/Seq.Extensions.Logging.Tests/Support/Some.cs
@@ -36,7 +36,7 @@ namespace Tests.Support
             {
                 throw new XunitException("Template could not be bound.");
             }
-            return new LogEvent(DateTimeOffset.Now, level, exception, template, properties);
+            return new LogEvent(DateTimeOffset.Now, level, exception, template, properties, default, default);
         }
 
         public static LogEvent DebugEvent()

--- a/test/Seq.Extensions.Logging.Tests/Support/Some.cs
+++ b/test/Seq.Extensions.Logging.Tests/Support/Some.cs
@@ -1,57 +1,70 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading;
 using Serilog.Events;
 using Xunit.Sdk;
 using Serilog.Core;
 using Microsoft.Extensions.Logging;
 using Serilog.Parameters;
+// ReSharper disable MemberCanBePrivate.Global
 
-namespace Tests.Support
+namespace Tests.Support;
+
+static class Some
 {
-    static class Some
+    public static LogEvent LogEvent(string messageTemplate, params object[] propertyValues)
     {
-        public static LogEvent LogEvent(string messageTemplate, params object[] propertyValues)
-        {
-            return LogEvent(null, messageTemplate, propertyValues);
-        }
+        return LogEvent(null, messageTemplate, propertyValues);
+    }
 
-        public static LogEvent LogEvent(Exception exception, string messageTemplate, params object[] propertyValues)
-        {
-            return LogEvent(LogLevel.Information, exception, messageTemplate, propertyValues);
-        }
+    public static LogEvent LogEvent(Exception exception, string messageTemplate, params object[] propertyValues)
+    {
+        return LogEvent(LogLevel.Information, exception, messageTemplate, propertyValues);
+    }
 
-        public static ILogEventPropertyFactory PropertyFactory()
-        {
-            return new PropertyValueConverter(10, 1024);
-        }
+    public static ILogEventPropertyFactory PropertyFactory()
+    {
+        return new PropertyValueConverter(10, 1024);
+    }
 
-        public static LogEvent LogEvent(LogLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
-        {
-            var log = new Logger(null, null, null);
-            MessageTemplate template;
-            IEnumerable<LogEventProperty> properties;
+    public static LogEvent LogEvent(LogLevel level, Exception exception, string messageTemplate, params object[] propertyValues)
+    {
+        var log = new Logger(null, null, null);
+        MessageTemplate template;
+        IEnumerable<LogEventProperty> properties;
 #pragma warning disable Serilog004 // Constant MessageTemplate verifier
-            if (!log.BindMessageTemplate(messageTemplate, propertyValues, out template, out properties))
+        if (!log.BindMessageTemplate(messageTemplate, propertyValues, out template, out properties))
 #pragma warning restore Serilog004 // Constant MessageTemplate verifier
-            {
-                throw new XunitException("Template could not be bound.");
-            }
-            return new LogEvent(DateTimeOffset.Now, level, exception, template, properties, default, default);
-        }
-
-        public static LogEvent DebugEvent()
         {
-            return LogEvent(LogLevel.Debug, null, "Debug event");
+            throw new XunitException("Template could not be bound.");
         }
+        return new LogEvent(DateTimeOffset.Now, level, exception, template, properties, default, default);
+    }
 
-        public static LogEvent InformationEvent()
-        {
-            return LogEvent(LogLevel.Information, null, "Information event");
-        }
+    public static LogEvent DebugEvent()
+    {
+        return LogEvent(LogLevel.Debug, null, "Debug event");
+    }
 
-        public static LogEvent ErrorEvent(Exception exception = null)
-        {
-            return LogEvent(LogLevel.Error, exception, "Error event");
-        }
+    public static LogEvent InformationEvent()
+    {
+        return LogEvent(LogLevel.Information, null, "Information event");
+    }
+
+    public static LogEvent ErrorEvent(Exception exception = null)
+    {
+        return LogEvent(LogLevel.Error, exception, "Error event");
+    }
+
+    static int _next;
+
+    public static int Int()
+    {
+        return Interlocked.Increment(ref _next);
+    }
+
+    public static string String()
+    {
+        return $"S_{Int()}";
     }
 }


### PR DESCRIPTION
By default, the built-in trace and span ids will be recorded alongside any span-related properties (such as `TraceId`, `SpanId`, and `ParentId`) that may be added by the framework:

![image](https://github.com/datalust/seq-extensions-logging/assets/342712/16cef2f3-f2c6-4b11-a258-f34f784ea30a)

To remove the redundant properties (if you wish) you can set `ActivityTrackingOptions` via `ILoggingBuilder.Configure()`:

```csharp
builder.Logging.Configure(opts => opts.ActivityTrackingOptions = ActivityTrackingOptions.None);
```

![image](https://github.com/datalust/seq-extensions-logging/assets/342712/b70f2ebe-a897-4ae3-ba63-5b97a1394c1b)

The PR draws on the trace and span correlation support I added upstream in Serilog, and I've followed it pretty closely here.