### PR TITLE
Upgrade to net9.0

### DIFF
--- a/example/ConsoleExample/ConsoleExample.csproj
+++ b/example/ConsoleExample/ConsoleExample.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/example/WebExample/WebExample.csproj
+++ b/example/WebExample/WebExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <Description>Add centralized structured log collection to ASP.NET Core apps with one line of code.</Description>
-    <VersionPrefix>8.0.1</VersionPrefix>
+    <VersionPrefix>9.0.0</VersionPrefix>
     <Authors>Datalust and Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../asset/seqext.snk</AssemblyOriginatorKeyFile>
@@ -23,9 +23,9 @@
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/test/Seq.Extensions.Logging.Tests/Seq.Extensions.Logging.Tests.csproj
+++ b/test/Seq.Extensions.Logging.Tests/Seq.Extensions.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../asset/seqext.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -14,13 +14,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.11.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
   </ItemGroup>
 

--- a/test/Seq.Extensions.Logging.Tests/Seq/Extensions/Logging/ExceptionDataEnricherTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Seq/Extensions/Logging/ExceptionDataEnricherTests.cs
@@ -18,7 +18,7 @@ public class ExceptionDataEnricherTests
 
         enricher.Enrich(evt, Some.PropertyValueFactory());
 
-        Assert.Equal(0, evt.Properties.Count);
+        Assert.Empty(evt.Properties);
     }
 
     [Fact]
@@ -37,7 +37,7 @@ public class ExceptionDataEnricherTests
 
         enricher.Enrich(evt, Some.PropertyValueFactory());
 
-        Assert.Equal(1, evt.Properties.Count);
+        Assert.Single(evt.Properties);
         var data = evt.Properties["ExceptionData"];
         var value = Assert.IsType<StructureValue>(data);
         Assert.Equal(2, value.Properties.Count);

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -131,7 +131,7 @@ public class SerilogLoggerTests
 
         Assert.Equal(3, sink.Writes.Count);
 
-        Assert.Equal(1, sink.Writes[0].Properties.Count);
+        Assert.Single(sink.Writes[0].Properties);
         Assert.Empty(sink.Writes[0].RenderMessage());
 
         Assert.Equal(2, sink.Writes[1].Properties.Count);


### PR DESCRIPTION
This PR updates the `Seq.Extensions.Logging` project to .NET 9. This involves dropping .NET 6 as a target because the `9.0.0` versions of MEL issue warnings that they weren't tested on this version.