### PR TITLE
Override EventId if set via state instead of throwing

### DIFF
--- a/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLogger.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Extensions/Logging/SerilogLogger.cs
@@ -110,7 +110,7 @@ class SerilogLogger : FrameworkLogger
         }
 
         if (eventId.Id != 0 || eventId.Name != null)
-            properties.Add("EventId", CreateEventIdPropertyValue(eventId));
+            properties["EventId"] = CreateEventIdPropertyValue(eventId);
 
         var parsedTemplate = MessageTemplateParser.Parse(messageTemplate ?? "");
         var currentActivity = Activity.Current;

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -245,6 +245,22 @@ public class SerilogLoggerTests
     }
 
     [Fact]
+    public void OverridesStateEventIdIfSpecified()
+    {
+        var (logger, sink) = SetUp(LogLevel.Trace);
+
+        const int expected = 3;
+        
+        logger.Log<KeyValuePair<string, object>[]>(LogLevel.Information, expected, state: [new("EventId", "Something")], exception: null, formatter: (s, e) => "");
+        
+        Assert.Single(sink.Writes);
+
+        var eventId = (StructureValue)sink.Writes[0].Properties["EventId"];
+        var id = (ScalarValue)eventId.Properties.Single(p => p.Name == "Id").Value;
+        Assert.Equal(expected, id.Value);
+    }
+
+    [Fact]
     public void BeginScopeDestructuresObjectsWhenDestructurerIsUsedInMessageTemplate()
     {
         var (logger, sink) = SetUp(LogLevel.Trace);


### PR DESCRIPTION
Closes #63 

cc @john-surcombe I've opted to override rather than respect the existing event id on properties so that it ends up using the correct computed value. How does this look to you?