### PR TITLE
Disable logging when level = LogLevel.None

### DIFF
--- a/src/Seq.Extensions.Logging/Serilog/Core/Logger.cs
+++ b/src/Seq.Extensions.Logging/Serilog/Core/Logger.cs
@@ -144,9 +144,7 @@ sealed class Logger : ILogEventSink, IDisposable
     /// <returns>True if the level is enabled; otherwise, false.</returns>
     public bool IsEnabled(LogLevel level)
     {
-
-        return _levelSwitch == null ||
-               (int)level >= (int)_levelSwitch.MinimumLevel;
+        return level != LogLevel.None && (_levelSwitch == null || level >= _levelSwitch.MinimumLevel);
     }
 
     /// <summary>

--- a/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
+++ b/test/Seq.Extensions.Logging.Tests/Serilog/Extensions/Logging/SerilogLoggerTests.cs
@@ -111,6 +111,19 @@ public class SerilogLoggerTests
     [InlineData(LogLevel.Critical, LogLevel.Warning, 0)]
     [InlineData(LogLevel.Critical, LogLevel.Error, 0)]
     [InlineData(LogLevel.Critical, LogLevel.Critical, 1)]
+    [InlineData(LogLevel.None, LogLevel.Trace, 0)]
+    [InlineData(LogLevel.None, LogLevel.Debug, 0)]
+    [InlineData(LogLevel.None, LogLevel.Information, 0)]
+    [InlineData(LogLevel.None, LogLevel.Warning, 0)]
+    [InlineData(LogLevel.None, LogLevel.Error, 0)]
+    [InlineData(LogLevel.None, LogLevel.Critical, 0)]
+    [InlineData(LogLevel.None, LogLevel.None, 0)]
+    [InlineData(LogLevel.Critical, LogLevel.None, 0)]
+    [InlineData(LogLevel.Error, LogLevel.None, 0)]
+    [InlineData(LogLevel.Warning, LogLevel.None, 0)]
+    [InlineData(LogLevel.Information, LogLevel.None, 0)]
+    [InlineData(LogLevel.Debug, LogLevel.None, 0)]
+    [InlineData(LogLevel.Trace, LogLevel.None, 0)]
     public void LogsWhenEnabled(LogLevel minLevel, LogLevel logLevel, int expected)
     {
         var (logger, sink) = SetUp(minLevel);


### PR DESCRIPTION
We have issues where log events with `LogLevel.None` are written to Seq, which it should not according to MS [LogLevel documentation](https://learn.microsoft.com/en-us/dotnet/api/microsoft.extensions.logging.loglevel?view=net-9.0-pp)