### PR TITLE
Add .NET 10 target framework and update dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,10 @@ jobs:
       - name: Setup
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.0.x
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
       - name: Compute build number
         shell: bash
         run: |

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,6 +1,6 @@
 <Project>
     <PropertyGroup>
-        <VersionPrefix>9.0.1</VersionPrefix>
+        <VersionPrefix>10.0.0</VersionPrefix>
         <LangVersion>latest</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>

--- a/README.md
+++ b/README.md
@@ -176,10 +176,8 @@ Seq.Extensions.Logging.SelfLog.Enable(message => {
 ### Versioning policy
 
 The major version of this package tracks the major version of its _Microsoft.Extensions.Logging_ dependency. So, if your
-application (on any target runtime) is targeting `net10.0`, use the latest 10.* version of this package. Likewise, if
-you're targeting `net8.0` or `net9.0`, a 10.* version of _Seq.Extensions.Logging_ targets those runtimes as well.
-Applications on older, out-of-support runtimes can continue to use the matching earlier major versions (e.g. 8.* for
-`net8.0`-only stacks).
+application (on any target runtime) is targeting `net6.0`, use the latest 6.* version of this package. Likewise, if
+you're targeting `net8.0`, target a 8.* version of _Seq.Extensions.Logging_ for the best experience.
 
 ### Credits
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This package makes it a one-liner to configure ASP.NET Core logging with Seq.
 
 ### Getting started
 
-The instructions that follow are for **.NET 6.0+** web applications.
+The instructions that follow are for **.NET 8.0+** web applications.
 
 Add [the NuGet package](https://nuget.org/packages/seq.extensions.logging) to your project either by editing the CSPROJ file, or using the NuGet package manager:
 
@@ -176,8 +176,10 @@ Seq.Extensions.Logging.SelfLog.Enable(message => {
 ### Versioning policy
 
 The major version of this package tracks the major version of its _Microsoft.Extensions.Logging_ dependency. So, if your
-application (on any target runtime) is targeting `net6.0`, use the latest 6.* version of this package. Likewise, if
-you're targeting `net8.0`, target a 8.* version of _Seq.Extensions.Logging_ for the best experience.
+application (on any target runtime) is targeting `net10.0`, use the latest 10.* version of this package. Likewise, if
+you're targeting `net8.0` or `net9.0`, a 10.* version of _Seq.Extensions.Logging_ targets those runtimes as well.
+Applications on older, out-of-support runtimes can continue to use the matching earlier major versions (e.g. 8.* for
+`net8.0`-only stacks).
 
 ### Credits
 

--- a/example/ConsoleExample/ConsoleExample.csproj
+++ b/example/ConsoleExample/ConsoleExample.csproj
@@ -2,15 +2,15 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/example/WebExample/WebExample.csproj
+++ b/example/WebExample/WebExample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
+++ b/src/Seq.Extensions.Logging/Seq.Extensions.Logging.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <Description>Add centralized structured log collection to ASP.NET Core apps with one line of code.</Description>
     <Authors>Datalust and Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0;net9.0;net10.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyOriginatorKeyFile>../../asset/seqext.snk</AssemblyOriginatorKeyFile>
@@ -19,9 +19,9 @@
 
   <ItemGroup>
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="9.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="10.0.9" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/test/Seq.Extensions.Logging.Tests/Seq.Extensions.Logging.Tests.csproj
+++ b/test/Seq.Extensions.Logging.Tests/Seq.Extensions.Logging.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net48;net8.0;net9.0;net10.0</TargetFrameworks>
     <AssemblyOriginatorKeyFile>../../asset/seqext.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
@@ -13,13 +13,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="17.12.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.0.0">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
+    <PackageReference Include="Microsoft.TestPlatform.ObjectModel" Version="18.7.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="Nullable" Version="1.3.1" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Adds `net10.0` as a supported target framework and updates the `Microsoft.Extensions.*` dependencies to the 10.0 release line, following the package's versioning policy that the major version tracks the major version of its `Microsoft.Extensions.Logging` dependency.

All existing, in-support target frameworks (`netstandard2.0`, `net8.0`, `net9.0`, and `net48` for tests) are retained.

## Changes

- **Library (`src/Seq.Extensions.Logging`)**
  - `TargetFrameworks`: added `net10.0` → `netstandard2.0;net8.0;net9.0;net10.0`
  - Updated `Microsoft.Extensions.Logging`, `.DependencyInjection`, and `.Logging.Configuration` to `10.0.9`
- **Tests (`test/Seq.Extensions.Logging.Tests`)**
  - `TargetFrameworks`: added `net10.0` → `net48;net8.0;net9.0;net10.0`
  - Updated `Microsoft.NET.Test.Sdk`, `Microsoft.TestPlatform.ObjectModel`, `xunit`, and `xunit.runner.visualstudio` to current releases
- **Examples**
  - `ConsoleExample` and `WebExample` retargample` package references updated to `10.0.9`
- **Build / CI**
  - `global.json` SDK pin updated from `9.0.ard: latestFeature`)
  - `ci.yml` `setup-dotnet` now installs `8.o every test TFM has its matching runtime
- **Versioning**
  - `VersionPrefix` bumped from `9.0.1` to `10.0.0`
- **README**
  - Getting-started note updated to reflect `.NET 8.0+`
  - Versioning policy rewritten to describe the 10.* release line and continued coverage of `net8.0`/`net9.0`

## Verification

- Library builds cleanly (0 warnings, 0 errors) for all four TFMs: `netstandard2.0`, `net8.0`, `net9.0`, `net10.0`
- Tests pass: 92/92 on `net10.0`, `net9.0`,  `net8.0`, and `net48`
- Example projects build and run on `net10.0

## Notes

- No source-code changes were done
- No breaking changes for consumers on older runtimes; existing TFMs and the public API are unchanged.